### PR TITLE
REFACTOR Improve support for custom ElementalArea relations in page templates.

### DIFF
--- a/tests/Extension/CMSPageAddControllerExtensionTest.php
+++ b/tests/Extension/CMSPageAddControllerExtensionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Dynamic\ElementalTemplates\Tests\Extension;
+
+use Psr\Log\LoggerInterface;
+use SilverStripe\Forms\Form;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Core\Injector\Injector;
+use DNADesign\Elemental\Models\ElementalArea;
+use Dynamic\ElementalTemplates\Models\Template;
+use Dynamic\ElememtalTemplates\Tests\TestOnly\SamplePage;
+use Dynamic\ElememtalTemplates\Tests\TestOnly\TestTemplate;
+use Dynamic\ElememtalTemplates\Extension\CMSPageAddControllerExtension;
+
+class CMSPageAddControllerExtensionTest extends SapphireTest
+{
+    protected static $fixture_file = 'CMSPageAddControllerExtensionTest.yml';
+
+    /**
+     * @var string[]
+     */
+    protected static $extra_dataobjects = [
+        SamplePage::class,
+        TestTemplate::class,
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Mock the logger
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        Injector::inst()->registerService($mockLogger, LoggerInterface::class);
+    }
+
+    public function testFindOrCreateElementalArea(): void
+    {
+        // Create a mock page with ElementalAreasExtension
+        $page = $this->objFromFixture(SamplePage::class, 'testPage');
+        $page->write();
+
+        // Apply the extension
+        $extension = new CMSPageAddControllerExtension();
+        $extension->setOwner($page);
+
+        // Use reflection to access the protected method
+        $reflection = new \ReflectionMethod($extension, 'findOrCreateElementalArea');
+        $reflection->setAccessible(true);
+
+        // Call findOrCreateElementalArea
+        $elementalArea = $reflection->invoke($extension, $page);
+
+        // Assert that an ElementalArea was created
+        $this->assertInstanceOf(ElementalArea::class, $elementalArea);
+        $this->assertTrue($elementalArea->exists());
+        $this->assertEquals($page->ElementalAreaID, $elementalArea->ID);
+    }
+
+    public function testUpdateDoAdd(): void
+    {
+        // Create a mock page and template
+        $page = $this->objFromFixture(SamplePage::class, 'testPage');
+        $template = $this->objFromFixture(TestTemplate::class, 'testTemplate');
+
+        // Mock the form
+        $mockForm = $this->createMock(Form::class);
+        $mockFields = $this->createMock(\SilverStripe\Forms\FieldList::class);
+        $mockField = $this->createMock(\SilverStripe\Forms\FormField::class);
+
+        $mockField->method('Value')->willReturn($template->ID);
+        $mockFields->method('dataFieldByName')->with('TemplateID')->willReturn($mockField);
+        $mockForm->method('Fields')->willReturn($mockFields);
+
+        // Apply the extension
+        $extension = new CMSPageAddControllerExtension();
+        $extension->setOwner($page);
+
+        // Call updateDoAdd
+        $extension->updateDoAdd($page, $mockForm);
+
+        // Assert that the ElementalArea has elements from the template
+        $elementalArea = $page->ElementalArea();
+        $this->assertNotNull($elementalArea, "ElementalArea is null");
+        $this->assertGreaterThan(0, $elementalArea->Elements()->count(), "ElementalArea has no elements");
+    }
+}

--- a/tests/Extension/CMSPageAddControllerExtensionTest.yml
+++ b/tests/Extension/CMSPageAddControllerExtensionTest.yml
@@ -1,0 +1,22 @@
+DNADesign\Elemental\Models\BaseElement:
+  testElement1:
+    Title: "Test Element 1"
+  testElement2:
+    Title: "Test Element 2"
+
+DNADesign\Elemental\Models\ElementalArea:
+  testElementalArea:
+    Elements:
+      - =>DNADesign\Elemental\Models\BaseElement.testElement1
+      - =>DNADesign\Elemental\Models\BaseElement.testElement2
+
+Dynamic\ElememtalTemplates\Tests\TestOnly\SamplePage:
+  testPage:
+    Title: "Test Page"
+    ClassName: "Page"
+    ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.testElementalArea
+
+Dynamic\ElememtalTemplates\Tests\TestOnly\TestTemplate:
+  testTemplate:
+    Title: "Test Template"
+    ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.testElementalArea

--- a/tests/TestOnly/SamplePage.php
+++ b/tests/TestOnly/SamplePage.php
@@ -13,4 +13,6 @@ class SamplePage extends \Page implements TestOnly
     private static array $extensions = [
         ElementalPageExtension::class,
     ];
+
+    private static $table_name = 'SamplePage';
 }

--- a/tests/TestOnly/TestTemplate.php
+++ b/tests/TestOnly/TestTemplate.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Dynamic\ElememtalTemplates\Tests\TestOnly;
+
+use Dynamic\ElememtalTemplates\Models\Template;
+
+class TestTemplate extends Template
+{
+    private static $table_name = 'TestTemplate';
+}


### PR DESCRIPTION
Previously, creating a page from a template only worked if the ElementalArea relation was named ElementalArea. This update finds the first ElementalArea relation for the class that has a corresponding field in getCMSFields().

For example, on Dynamic\Base\Page\HomePage, where ElementalHomePage is defined as a has_one and ElementalArea is hidden, blocks will now be copied to ElementalHomePage.