### PR TITLE
BUGFIX resolve ActionsPage table conflict in TemplatePreviewController tests

### DIFF
--- a/tests/Controller/TemplatePreviewControllerTest.php
+++ b/tests/Controller/TemplatePreviewControllerTest.php
@@ -13,9 +13,9 @@ class TemplatePreviewControllerTest extends FunctionalTest
     {
         parent::setUp();
 
-        // Run dev/build to ensure the database schema is up to date
+        // Tests are currently skipped, so no database setup needed
         $this->logInWithPermission('ADMIN');
-        $this->get('dev/build?flush=1');
+        // Note: dev/build removed to avoid ActionsPage table conflicts from cms-actions dependency
     }
 
     public function testTemplatePreviewPageLoadsSuccessfully()


### PR DESCRIPTION
## Problem

The `TemplatePreviewControllerTest` was failing with database errors:
```
Table 'db.ActionsPage' doesn't exist
```

This occurred because the `setUp()` method was calling `dev/build` which attempted to build all database tables including TestOnly classes from dependencies. The `Test_ActionsPage` class from the `lekoala/silverstripe-cms-actions` dependency was being discovered during dev/build but couldn't be properly instantiated in the test database context.

## Solution

Since both test methods in `TemplatePreviewControllerTest` are marked as skipped with `$this->markTestSkipped()`, the `dev/build` call in `setUp()` is unnecessary and was causing the database table conflicts.

**Changes:**
- Remove the `dev/build` call from `setUp()` method
- Add explanatory comment about why dev/build was removed
- Tests now pass cleanly: 21 tests, 66 assertions, 2 skipped

## Testing

Before fix:
```
ERRORS!
Tests: 21, Assertions: 66, Errors: 2.
```

After fix:
```
OK, but incomplete, skipped, or risky tests!
Tests: 21, Assertions: 66, Skipped: 2.
```

This maintains the existing test behavior (both tests remain skipped as intended) while eliminating the database table conflicts that were preventing the test suite from running cleanly.