### PR TITLE
feat: Browser-based screenshot capture for template previews

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -6,3 +6,4 @@ After:
 SilverStripe\Control\Director:
   rules:
     'template-preview/$ID/$Action': Dynamic\ElementalTemplates\Controller\TemplatePreviewController
+    'template-screenshot-upload//$Action': Dynamic\ElementalTemplates\Controller\ScreenshotUploadController

--- a/client/dist/js/screenshot-capture.js
+++ b/client/dist/js/screenshot-capture.js
@@ -185,7 +185,7 @@
                     backgroundColor: '#ffffff',
                     logging: false,
                     windowWidth: 1400, // Force lg breakpoint width for desktop layout
-                    width: content.scrollWidth || 1400,
+                    width: 1400, // Fixed width to match preview and prevent horizontal overflow
                 });
 
                 statusText.textContent = 'Uploading...';

--- a/client/dist/js/screenshot-capture.js
+++ b/client/dist/js/screenshot-capture.js
@@ -1,0 +1,256 @@
+/**
+ * Screenshot Capture for Template LayoutImage
+ * 
+ * Uses html2canvas to capture content-only preview and uploads as LayoutImage.
+ * Requires html2canvas library (loaded from CDN if not available).
+ */
+(function () {
+    'use strict';
+
+    // Load html2canvas from CDN if not available
+    function loadHtml2Canvas() {
+        return new Promise((resolve, reject) => {
+            if (window.html2canvas) {
+                resolve(window.html2canvas);
+                return;
+            }
+
+            const script = document.createElement('script');
+            script.src = 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js';
+            script.onload = () => resolve(window.html2canvas);
+            script.onerror = () => reject(new Error('Failed to load html2canvas'));
+            document.head.appendChild(script);
+        });
+    }
+
+    // Create and show modal with preview iframe
+    function showCaptureModal(previewUrl, templateId, uploadUrl, securityId) {
+        // Create overlay
+        const overlay = document.createElement('div');
+        overlay.className = 'screenshot-capture-overlay';
+        overlay.style.cssText = `
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.8);
+            z-index: 10000;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+        `;
+
+        // Create modal container
+        const modal = document.createElement('div');
+        modal.className = 'screenshot-capture-modal';
+        modal.style.cssText = `
+            background: white;
+            border-radius: 8px;
+            max-width: 90vw;
+            max-height: 85vh;
+            display: flex;
+            flex-direction: column;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+        `;
+
+        // Create header
+        const header = document.createElement('div');
+        header.style.cssText = `
+            padding: 16px 20px;
+            border-bottom: 1px solid #e0e0e0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        `;
+        header.innerHTML = `
+            <h3 style="margin: 0; font-size: 18px; color: #333;">Capture Preview Image</h3>
+            <button type="button" class="close-btn" style="border: none; background: none; font-size: 24px; cursor: pointer; color: #666;">&times;</button>
+        `;
+
+        // Create iframe container - scrollable to show desktop preview
+        const iframeContainer = document.createElement('div');
+        iframeContainer.style.cssText = `
+            flex: 1;
+            overflow: auto;
+            padding: 20px;
+            min-height: 400px;
+            max-height: 600px;
+        `;
+
+        // Use lg breakpoint width (1400px) to ensure desktop 3-column layout
+        const iframe = document.createElement('iframe');
+        iframe.src = previewUrl;
+        iframe.style.cssText = `
+            width: 1400px;
+            min-width: 1400px;
+            height: 900px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            transform-origin: top left;
+        `;
+        iframeContainer.appendChild(iframe);
+
+        // Create footer with action buttons
+        const footer = document.createElement('div');
+        footer.style.cssText = `
+            padding: 16px 20px;
+            border-top: 1px solid #e0e0e0;
+            display: flex;
+            justify-content: flex-end;
+            gap: 12px;
+        `;
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.textContent = 'Cancel';
+        cancelBtn.style.cssText = `
+            padding: 8px 16px;
+            border: 1px solid #ddd;
+            background: white;
+            border-radius: 4px;
+            cursor: pointer;
+        `;
+
+        const captureBtn = document.createElement('button');
+        captureBtn.type = 'button';
+        captureBtn.textContent = 'Capture Screenshot';
+        captureBtn.className = 'btn-primary';
+        captureBtn.style.cssText = `
+            padding: 8px 16px;
+            border: none;
+            background: #0071c4;
+            color: white;
+            border-radius: 4px;
+            cursor: pointer;
+            font-weight: 500;
+        `;
+        captureBtn.disabled = true;
+
+        const statusText = document.createElement('span');
+        statusText.style.cssText = `
+            flex: 1;
+            color: #666;
+            font-size: 14px;
+        `;
+        statusText.textContent = 'Loading preview...';
+
+        footer.appendChild(statusText);
+        footer.appendChild(cancelBtn);
+        footer.appendChild(captureBtn);
+
+        // Assemble modal
+        modal.appendChild(header);
+        modal.appendChild(iframeContainer);
+        modal.appendChild(footer);
+        overlay.appendChild(modal);
+        document.body.appendChild(overlay);
+
+        // Enable capture button when iframe loads
+        iframe.onload = function () {
+            captureBtn.disabled = false;
+            statusText.textContent = 'Ready to capture';
+        };
+
+        // Close handlers
+        function closeModal() {
+            overlay.remove();
+        }
+
+        header.querySelector('.close-btn').onclick = closeModal;
+        cancelBtn.onclick = closeModal;
+        overlay.addEventListener('click', function (e) {
+            if (e.target === overlay) closeModal();
+        });
+
+        // Capture handler
+        captureBtn.onclick = async function () {
+            captureBtn.disabled = true;
+            statusText.textContent = 'Capturing screenshot...';
+
+            try {
+                await loadHtml2Canvas();
+
+                // Access iframe content
+                const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+                const content = iframeDoc.querySelector('.template-preview-container') || iframeDoc.body;
+
+                // Capture with html2canvas at desktop width
+                const canvas = await html2canvas(content, {
+                    useCORS: true,
+                    allowTaint: true,
+                    scale: 1,
+                    backgroundColor: '#ffffff',
+                    logging: false,
+                    windowWidth: 1400, // Force lg breakpoint width for desktop layout
+                    width: content.scrollWidth || 1400,
+                });
+
+                statusText.textContent = 'Uploading...';
+
+                // Convert to base64
+                const imageData = canvas.toDataURL('image/png');
+
+                // Upload to server
+                const formData = new FormData();
+                formData.append('templateID', templateId);
+                formData.append('screenshot', imageData);
+                formData.append('SecurityID', securityId);
+
+                const response = await fetch(uploadUrl, {
+                    method: 'POST',
+                    body: formData,
+                });
+
+                const result = await response.json();
+
+                if (result.success) {
+                    statusText.textContent = 'Screenshot saved successfully!';
+                    statusText.style.color = '#28a745';
+
+                    setTimeout(() => {
+                        closeModal();
+                        // Reload the form to show updated image
+                        window.location.reload();
+                    }, 1500);
+                } else {
+                    throw new Error(result.error || 'Upload failed');
+                }
+            } catch (error) {
+                console.error('Screenshot capture failed:', error);
+                statusText.textContent = 'Error: ' + error.message;
+                statusText.style.color = '#dc3545';
+                captureBtn.disabled = false;
+            }
+        };
+    }
+
+    // Bind to CMS actions using Entwine
+    if (typeof jQuery !== 'undefined' && jQuery.entwine) {
+        jQuery.entwine('ss', function ($) {
+            // LeKoala CMS Actions uses a different name pattern
+            $('button[name="action_doCustomAction[CaptureScreenshot]"]').entwine({
+                onclick: function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+
+                    const btn = this[0];
+                    const previewUrl = btn.dataset.previewUrl;
+                    const templateId = btn.dataset.templateId;
+                    const uploadUrl = btn.dataset.uploadUrl;
+                    const securityId = btn.dataset.securityId;
+
+                    if (!previewUrl || !templateId) {
+                        console.error('Missing required data attributes for screenshot capture');
+                        return false;
+                    }
+
+                    showCaptureModal(previewUrl, templateId, uploadUrl, securityId);
+                    return false;
+                }
+            });
+        });
+    }
+})();

--- a/client/dist/styles/template-picker.css
+++ b/client/dist/styles/template-picker.css
@@ -4,6 +4,14 @@
  */
 
 /* ============================================
+   Hide "Apply Blocks Template" from dropdown
+   (Still needed for JS triggering, just hidden from users)
+   ============================================ */
+#Form_EditForm_action_doCustomAction_ApplyTemplate {
+    display: none !important;
+}
+
+/* ============================================
    Field Container
    ============================================ */
 .template-picker-field {

--- a/src/Admin/TemplateAdmin.php
+++ b/src/Admin/TemplateAdmin.php
@@ -4,6 +4,7 @@ namespace Dynamic\ElementalTemplates\Admin;
 
 use Dynamic\ElementalTemplates\Models\Template;
 use SilverStripe\Admin\ModelAdmin;
+use SilverStripe\View\Requirements;
 
 /**
  * Class \Dynamic\ElementalTemplates\Admin\TemplateAdmin
@@ -32,4 +33,17 @@ class TemplateAdmin extends ModelAdmin
      * @var string
      */
     private static string $menu_icon_class = 'font-icon-block-layout';
+
+    /**
+     * Initialize admin with required JS for screenshot capture.
+     */
+    protected function init(): void
+    {
+        parent::init();
+        
+        // Require screenshot capture JS for the Capture Preview Image button
+        Requirements::javascript(
+            'dynamic/silverstripe-elemental-templates:client/dist/js/screenshot-capture.js'
+        );
+    }
 }

--- a/src/Admin/TemplateAdmin.php
+++ b/src/Admin/TemplateAdmin.php
@@ -40,7 +40,7 @@ class TemplateAdmin extends ModelAdmin
     protected function init(): void
     {
         parent::init();
-        
+
         // Require screenshot capture JS for the Capture Preview Image button
         Requirements::javascript(
             'dynamic/silverstripe-elemental-templates:client/dist/js/screenshot-capture.js'

--- a/src/Controller/ScreenshotUploadController.php
+++ b/src/Controller/ScreenshotUploadController.php
@@ -93,7 +93,7 @@ class ScreenshotUploadController extends Controller
 
             // Save the image
             $image = $this->saveScreenshot($template, $imageData);
-            
+
             // Update template's LayoutImage
             $template->LayoutImageID = $image->ID;
             $template->write();

--- a/src/Controller/ScreenshotUploadController.php
+++ b/src/Controller/ScreenshotUploadController.php
@@ -181,7 +181,7 @@ class ScreenshotUploadController extends Controller
     protected function saveScreenshot(Template $template, array $imageData): Image
     {
         // Use uniqid for better filename uniqueness than time()
-        $filename = 'template-preview-' . $template->ID . '-' . uniqid('', true) . '.' . $imageData['extension'];
+        $filename = 'template-preview-' . $template->ID . '-' . uniqid() . '.' . $imageData['extension'];
         $folderPath = 'Uploads/template-screenshots';
 
         // Create temp file

--- a/src/Controller/ScreenshotUploadController.php
+++ b/src/Controller/ScreenshotUploadController.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Dynamic\ElementalTemplates\Controller;
+
+use Dynamic\ElementalTemplates\Models\Template;
+use SilverStripe\Assets\Image;
+use SilverStripe\Assets\Upload;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Security\Security;
+use SilverStripe\Security\SecurityToken;
+
+/**
+ * Controller for handling screenshot uploads from the CMS.
+ * Receives base64-encoded image data and saves it as the template's LayoutImage.
+ */
+class ScreenshotUploadController extends Controller
+{
+    private static $url_segment = 'template-screenshot-upload';
+
+    private static $url_handlers = [
+        'upload' => 'upload',
+        '' => 'index',
+    ];
+
+    private static $allowed_actions = [
+        'upload',
+        'index',
+    ];
+
+    /**
+     * Default action - returns error for direct access.
+     *
+     * @return HTTPResponse
+     */
+    public function index(): HTTPResponse
+    {
+        return $this->jsonResponse(['error' => 'POST to /upload required'], 400);
+    }
+
+    /**
+     * Handle screenshot upload from CMS.
+     * Expects POST with:
+     * - templateID: int
+     * - screenshot: base64 encoded image data
+     * - SecurityID: CSRF token
+     *
+     * @param HTTPRequest $request
+     * @return HTTPResponse
+     */
+    public function upload(HTTPRequest $request): HTTPResponse
+    {
+        // Check for logged in user
+        $member = Security::getCurrentUser();
+        if (!$member) {
+            return $this->jsonResponse(['error' => 'Not authenticated'], 401);
+        }
+
+        // Verify CSRF token
+        if (!SecurityToken::inst()->checkRequest($request)) {
+            return $this->jsonResponse(['error' => 'Invalid security token'], 403);
+        }
+
+        // Only accept POST
+        if (!$request->isPOST()) {
+            return $this->jsonResponse(['error' => 'POST required'], 405);
+        }
+
+        $templateID = (int) $request->postVar('templateID');
+        $screenshotData = $request->postVar('screenshot');
+
+        if (!$templateID || !$screenshotData) {
+            return $this->jsonResponse(['error' => 'Missing required parameters'], 400);
+        }
+
+        // Find template
+        $template = Template::get()->byID($templateID);
+        if (!$template) {
+            return $this->jsonResponse(['error' => 'Template not found'], 404);
+        }
+
+        // Check edit permission
+        if (!$template->canEdit($member)) {
+            return $this->jsonResponse(['error' => 'Permission denied'], 403);
+        }
+
+        try {
+            // Decode base64 image
+            $imageData = $this->decodeBase64Image($screenshotData);
+            if (!$imageData) {
+                return $this->jsonResponse(['error' => 'Invalid image data'], 400);
+            }
+
+            // Save the image
+            $image = $this->saveScreenshot($template, $imageData);
+            
+            // Update template's LayoutImage
+            $template->LayoutImageID = $image->ID;
+            $template->write();
+
+            return $this->jsonResponse([
+                'success' => true,
+                'message' => 'Screenshot saved successfully',
+                'imageID' => $image->ID,
+                'imageURL' => $image->getURL(),
+            ]);
+        } catch (\Exception $e) {
+            return $this->jsonResponse(['error' => 'Failed to save screenshot: ' . $e->getMessage()], 500);
+        }
+    }
+
+    /**
+     * Decode base64 image data.
+     *
+     * @param string $base64Data
+     * @return array|null ['mime' => string, 'data' => binary]
+     */
+    protected function decodeBase64Image(string $base64Data): ?array
+    {
+        // Remove data URL prefix if present
+        if (preg_match('/^data:image\/(\w+);base64,/', $base64Data, $matches)) {
+            $extension = $matches[1];
+            $base64Data = substr($base64Data, strpos($base64Data, ',') + 1);
+        } else {
+            $extension = 'png';
+        }
+
+        $data = base64_decode($base64Data);
+        if ($data === false) {
+            return null;
+        }
+
+        $mimeTypes = [
+            'png' => 'image/png',
+            'jpg' => 'image/jpeg',
+            'jpeg' => 'image/jpeg',
+            'gif' => 'image/gif',
+            'webp' => 'image/webp',
+        ];
+
+        return [
+            'extension' => $extension,
+            'mime' => $mimeTypes[$extension] ?? 'image/png',
+            'data' => $data,
+        ];
+    }
+
+    /**
+     * Save screenshot as an Image asset.
+     *
+     * @param Template $template
+     * @param array $imageData
+     * @return Image
+     */
+    protected function saveScreenshot(Template $template, array $imageData): Image
+    {
+        $filename = 'template-preview-' . $template->ID . '-' . time() . '.' . $imageData['extension'];
+        $folderPath = 'Uploads/template-screenshots';
+
+        // Create temp file
+        $tempPath = TEMP_PATH . '/' . $filename;
+        file_put_contents($tempPath, $imageData['data']);
+
+        // Create new image (always create new to avoid issues with existing)
+        $image = Image::create();
+        $image->setFromLocalFile($tempPath, $folderPath . '/' . $filename);
+        $image->write();
+
+        // Clean up temp file
+        if (file_exists($tempPath)) {
+            unlink($tempPath);
+        }
+
+        // Publish the image
+        $image->publishSingle();
+
+        return $image;
+    }
+
+    /**
+     * Return JSON response.
+     *
+     * @param array $data
+     * @param int $code
+     * @return HTTPResponse
+     */
+    protected function jsonResponse(array $data, int $code = 200): HTTPResponse
+    {
+        $response = HTTPResponse::create(json_encode($data));
+        $response->addHeader('Content-Type', 'application/json');
+        $response->setStatusCode($code);
+        return $response;
+    }
+}

--- a/src/Controller/ScreenshotUploadController.php
+++ b/src/Controller/ScreenshotUploadController.php
@@ -4,7 +4,6 @@ namespace Dynamic\ElementalTemplates\Controller;
 
 use Dynamic\ElementalTemplates\Models\Template;
 use SilverStripe\Assets\Image;
-use SilverStripe\Assets\Upload;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
@@ -120,10 +119,10 @@ class ScreenshotUploadController extends Controller
     {
         // Remove data URL prefix if present
         if (preg_match('/^data:image\/(\w+);base64,/', $base64Data, $matches)) {
-            $extension = $matches[1];
+            $declaredExtension = $matches[1];
             $base64Data = substr($base64Data, strpos($base64Data, ',') + 1);
         } else {
-            $extension = 'png';
+            $declaredExtension = 'png';
         }
 
         $data = base64_decode($base64Data);
@@ -131,17 +130,43 @@ class ScreenshotUploadController extends Controller
             return null;
         }
 
+        // Validate that the decoded data is actually a valid image
+        $imageInfo = @getimagesizefromstring($data);
+        if ($imageInfo === false) {
+            return null;
+        }
+
+        // Map IMAGETYPE constants to extensions
+        $typeToExtension = [
+            IMAGETYPE_PNG => 'png',
+            IMAGETYPE_JPEG => 'jpg',
+            IMAGETYPE_GIF => 'gif',
+            IMAGETYPE_WEBP => 'webp',
+        ];
+
+        $actualExtension = $typeToExtension[$imageInfo[2]] ?? null;
+        if (!$actualExtension) {
+            return null; // Unsupported image type
+        }
+
+        // Normalize declared extension
+        $normalizedDeclared = ($declaredExtension === 'jpeg') ? 'jpg' : $declaredExtension;
+
+        // Ensure actual image type matches declared extension
+        if ($actualExtension !== $normalizedDeclared) {
+            return null;
+        }
+
         $mimeTypes = [
             'png' => 'image/png',
             'jpg' => 'image/jpeg',
-            'jpeg' => 'image/jpeg',
             'gif' => 'image/gif',
             'webp' => 'image/webp',
         ];
 
         return [
-            'extension' => $extension,
-            'mime' => $mimeTypes[$extension] ?? 'image/png',
+            'extension' => $actualExtension,
+            'mime' => $mimeTypes[$actualExtension] ?? 'image/png',
             'data' => $data,
         ];
     }
@@ -155,27 +180,31 @@ class ScreenshotUploadController extends Controller
      */
     protected function saveScreenshot(Template $template, array $imageData): Image
     {
-        $filename = 'template-preview-' . $template->ID . '-' . time() . '.' . $imageData['extension'];
+        // Use uniqid for better filename uniqueness than time()
+        $filename = 'template-preview-' . $template->ID . '-' . uniqid('', true) . '.' . $imageData['extension'];
         $folderPath = 'Uploads/template-screenshots';
 
         // Create temp file
         $tempPath = TEMP_PATH . '/' . $filename;
-        file_put_contents($tempPath, $imageData['data']);
 
-        // Create new image (always create new to avoid issues with existing)
-        $image = Image::create();
-        $image->setFromLocalFile($tempPath, $folderPath . '/' . $filename);
-        $image->write();
+        try {
+            file_put_contents($tempPath, $imageData['data']);
 
-        // Clean up temp file
-        if (file_exists($tempPath)) {
-            unlink($tempPath);
+            // Create new image (always create new to avoid issues with existing)
+            $image = Image::create();
+            $image->setFromLocalFile($tempPath, $folderPath . '/' . $filename);
+            $image->write();
+
+            // Publish the image
+            $image->publishSingle();
+
+            return $image;
+        } finally {
+            // Clean up temp file
+            if (file_exists($tempPath)) {
+                unlink($tempPath);
+            }
         }
-
-        // Publish the image
-        $image->publishSingle();
-
-        return $image;
     }
 
     /**

--- a/src/Controller/ScreenshotUploadController.php
+++ b/src/Controller/ScreenshotUploadController.php
@@ -184,8 +184,8 @@ class ScreenshotUploadController extends Controller
         $filename = 'template-preview-' . $template->ID . '-' . uniqid() . '.' . $imageData['extension'];
         $folderPath = 'Uploads/template-screenshots';
 
-        // Create temp file
-        $tempPath = TEMP_PATH . '/' . $filename;
+        // Create a unique temp file path using the system API to avoid race conditions
+        $tempPath = tempnam(TEMP_PATH, 'screenshot_');
 
         try {
             file_put_contents($tempPath, $imageData['data']);

--- a/src/Controller/TemplatePreviewController.php
+++ b/src/Controller/TemplatePreviewController.php
@@ -2,13 +2,17 @@
 
 namespace Dynamic\ElementalTemplates\Controller;
 
-use App\PageController;
-use SilverStripe\Dev\Debug;
 use SilverStripe\View\Requirements;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\ORM\FieldType\DBField;
 use Dynamic\ElementalTemplates\Models\Template;
 
+/**
+ * Controller for rendering template previews.
+ * Supports two modes:
+ * - Full page preview (default): Renders template within Page.ss wrapper
+ * - Content-only mode (?content_only=1): Renders only elemental area for screenshots
+ */
 class TemplatePreviewController extends \PageController
 {
     private static $allowed_actions = [
@@ -18,7 +22,6 @@ class TemplatePreviewController extends \PageController
     protected function init()
     {
         parent::init();
-        // Removed unnecessary CSS requirement for preview.css
     }
 
     public function index()
@@ -35,6 +38,45 @@ class TemplatePreviewController extends \PageController
             return $this->httpError(500, 'Invalid Page Type');
         }
 
+        // Check for content-only mode (for screenshots)
+        $contentOnly = $this->getRequest()->getVar('content_only');
+
+        if ($contentOnly) {
+            return $this->renderContentOnly($template, $pageType);
+        }
+
+        return $this->renderFullPage($template, $pageType);
+    }
+
+    /**
+     * Render content-only mode for clean screenshots.
+     * Shows only the elemental area without page wrapper (header/footer).
+     *
+     * @param Template $template
+     * @param string $pageType
+     * @return \SilverStripe\ORM\FieldType\DBHTMLText
+     */
+    protected function renderContentOnly(Template $template, string $pageType)
+    {
+        $page = $pageType::create();
+        $page->Title = $template->Title;
+        $page->ElementalArea = $template->Elements();
+
+        return $this->customise([
+            'Template' => $template,
+            'Page' => $page,
+        ])->renderWith('Dynamic\\ElementalTemplates\\Layout\\TemplatePreviewContent');
+    }
+
+    /**
+     * Render full page preview with page wrapper (header/footer).
+     *
+     * @param Template $template
+     * @param string $pageType
+     * @return \SilverStripe\ORM\FieldType\DBHTMLText
+     */
+    protected function renderFullPage(Template $template, string $pageType)
+    {
         $page = $pageType::create();
         $page->Title = $template->Title;
 
@@ -57,7 +99,7 @@ class TemplatePreviewController extends \PageController
         // Render the Page.ss template with the Layout variable properly set
         return $this->customise([
             'Page' => $page,
-            'Layout' => DBField::create_field('HTMLText', $layoutContent) // Ensure the layout is treated as HTML
+            'Layout' => DBField::create_field('HTMLText', $layoutContent)
         ])->renderWith('Page');
     }
 }

--- a/src/Extension/SiteTreeExtension.php
+++ b/src/Extension/SiteTreeExtension.php
@@ -103,7 +103,8 @@ class SiteTreeExtension extends DataExtension
                     ->setAttribute('data-url', $this->owner->Link('CreateTemplate'))
             );
 
-            // "Apply Blocks Template" action - used by the template picker's Apply button
+            // "Apply Blocks Template" action - triggered by template picker's Apply button
+            // Hidden from dropdown via CSS, but needed for JS form submission handling
             if ($this->getOwner()->ID) {
                 $moreOptions->insertAfter(
                     'CreateTemplate',

--- a/src/Models/Template.php
+++ b/src/Models/Template.php
@@ -266,8 +266,8 @@ class Template extends DataObject implements PermissionProvider
     }
 
     /**
-     * Returns a 200x200 square thumbnail for the layout image in summary fields.
-     * Matches the dimensions used in the template picker field.
+     * Returns a thumbnail for the layout image in summary fields.
+     * Uses ScaleWidth to preserve aspect ratio like TemplatePickerField.
      * Includes click-to-enlarge functionality with accessibility support.
      *
      * @return DBHTMLText
@@ -275,8 +275,8 @@ class Template extends DataObject implements PermissionProvider
     public function getLayoutImageThumbnail()
     {
         if ($this->LayoutImage() && $this->LayoutImage()->exists()) {
-            // Use FillMax for 200x200 square cropped image (matches template picker)
-            $thumbnail = $this->LayoutImage()->FillMax(200, 200);
+            // Use ScaleWidth for aspect-ratio preserving thumbnail (matches template picker)
+            $thumbnail = $this->LayoutImage()->ScaleWidth(200);
             // Use original image for enlarged view to avoid extra scaling
             $fullUrl = $this->LayoutImage()->getURL();
 
@@ -288,7 +288,7 @@ class Template extends DataObject implements PermissionProvider
                 $fullUrlJs = json_encode($fullUrl);
 
                 $html = sprintf(
-                    '<div style="position: relative; display: inline-block;"><img src="%s" alt="%s" role="button" tabindex="0" aria-label="View larger version of %s" style="width: 200px; height: 200px; object-fit: cover; object-position: top center; display: block; cursor: pointer; border-radius: 4px;" onclick="event.stopPropagation();if(window.__templateOverlay&&window.__templateOverlay.parentNode){window.__templateOverlay.parentNode.removeChild(window.__templateOverlay);window.__templateOverlay=null;}var previouslyFocused=document.activeElement;var overlay=document.createElement(\'div\');overlay.setAttribute(\'role\',\'dialog\');overlay.setAttribute(\'aria-modal\',\'true\');overlay.setAttribute(\'aria-label\',\'Enlarged template preview\');overlay.style.cssText=\'position:fixed;top:0;left:0;width:100%%;height:100%%;background:rgba(0,0,0,0.8);z-index:10000;display:flex;align-items:center;justify-content:center;cursor:pointer;\';overlay.tabIndex=-1;var img=document.createElement(\'img\');img.src=%s;img.alt=%s;img.style.cssText=\'max-width:90%%;max-height:90%%;box-shadow:0 0 20px rgba(0,0,0,0.5);\';overlay.appendChild(img);var closeOverlay=function(){if(overlay&&overlay.parentNode){overlay.parentNode.removeChild(overlay);if(window.__templateOverlay===overlay){window.__templateOverlay=null;}if(previouslyFocused&&typeof previouslyFocused.focus===\'function\'){previouslyFocused.focus();}}};overlay.onclick=function(event){if(event.target===overlay){closeOverlay();}};overlay.addEventListener(\'keydown\',function(e){if(e.key===\'Escape\'||e.key===\'Esc\'){e.preventDefault();closeOverlay();}else if(e.key===\'Tab\'){e.preventDefault();overlay.focus();}});document.body.appendChild(overlay);window.__templateOverlay=overlay;overlay.focus();" onkeydown="if(event.key===\'Enter\'||event.key===\' \'||event.key===\'Spacebar\'){event.preventDefault();this.click();}" title="Click to view larger" /></div>',
+                    '<div style="position: relative; display: inline-block;"><img src="%s" alt="%s" role="button" tabindex="0" aria-label="View larger version of %s" style="width: 200px; height: auto; max-height: 300px; object-fit: contain; display: block; cursor: pointer; border-radius: 4px;" onclick="event.stopPropagation();if(window.__templateOverlay&&window.__templateOverlay.parentNode){window.__templateOverlay.parentNode.removeChild(window.__templateOverlay);window.__templateOverlay=null;}var previouslyFocused=document.activeElement;var overlay=document.createElement(\'div\');overlay.setAttribute(\'role\',\'dialog\');overlay.setAttribute(\'aria-modal\',\'true\');overlay.setAttribute(\'aria-label\',\'Enlarged template preview\');overlay.style.cssText=\'position:fixed;top:0;left:0;width:100%%;height:100%%;background:rgba(0,0,0,0.8);z-index:10000;display:flex;align-items:center;justify-content:center;cursor:pointer;\';overlay.tabIndex=-1;var img=document.createElement(\'img\');img.src=%s;img.alt=%s;img.style.cssText=\'max-width:90%%;max-height:90%%;box-shadow:0 0 20px rgba(0,0,0,0.5);\';overlay.appendChild(img);var closeOverlay=function(){if(overlay&&overlay.parentNode){overlay.parentNode.removeChild(overlay);if(window.__templateOverlay===overlay){window.__templateOverlay=null;}if(previouslyFocused&&typeof previouslyFocused.focus===\'function\'){previouslyFocused.focus();}}};overlay.onclick=function(event){if(event.target===overlay){closeOverlay();}};overlay.addEventListener(\'keydown\',function(e){if(e.key===\'Escape\'||e.key===\'Esc\'){e.preventDefault();closeOverlay();}else if(e.key===\'Tab\'){e.preventDefault();overlay.focus();}});document.body.appendChild(overlay);window.__templateOverlay=overlay;overlay.focus();" onkeydown="if(event.key===\'Enter\'||event.key===\' \'||event.key===\'Spacebar\'){event.preventDefault();this.click();}" title="Click to view larger" /></div>',
                     $thumbnailUrl,
                     $title,
                     $title,

--- a/src/Models/Template.php
+++ b/src/Models/Template.php
@@ -460,6 +460,33 @@ class Template extends DataObject implements PermissionProvider
                 ->setAttribute('onclick', "window.open('{$this->getPreviewLink()}', '_blank')")
         );
 
+        // Add screenshot capture button (only for saved templates with elements)
+        if ($this->exists() && $this->Elements() && $this->Elements()->Elements()->count() > 0) {
+            $contentOnlyUrl = $this->getPreviewLink() . '?content_only=1';
+            $templateID = $this->ID;
+            $securityToken = \SilverStripe\Security\SecurityToken::getSecurityID();
+            
+            $actions->push(
+                CustomAction::create('CaptureScreenshot', 'Capture Preview Image')
+                    ->setUseButtonTag(true)
+                    ->addExtraClass('btn-outline-secondary font-icon-upload')
+                    ->setAttribute('data-template-id', $templateID)
+                    ->setAttribute('data-preview-url', $contentOnlyUrl)
+                    ->setAttribute('data-upload-url', '/template-screenshot-upload/upload')
+                    ->setAttribute('data-security-id', $securityToken)
+            );
+        }
+
         return $actions;
+    }
+
+    /**
+     * Get the content-only preview URL for screenshot capture.
+     *
+     * @return string
+     */
+    public function getContentOnlyPreviewLink(): string
+    {
+        return $this->getPreviewLink() . '?content_only=1';
     }
 }

--- a/src/Models/Template.php
+++ b/src/Models/Template.php
@@ -465,7 +465,7 @@ class Template extends DataObject implements PermissionProvider
             $contentOnlyUrl = $this->getPreviewLink() . '?content_only=1';
             $templateID = $this->ID;
             $securityToken = \SilverStripe\Security\SecurityToken::getSecurityID();
-            
+
             $actions->push(
                 CustomAction::create('CaptureScreenshot', 'Capture Preview Image')
                     ->setUseButtonTag(true)

--- a/src/Service/TemplateElementDuplicator.php
+++ b/src/Service/TemplateElementDuplicator.php
@@ -62,7 +62,6 @@ class TemplateElementDuplicator
 
                 // Add the duplicated element to the target area
                 $area->Elements()->add($copy);
-
             } catch (\Exception $ex) {
                 $logger->error(sprintf(
                     "Error duplicating element (ID: %d): %s",

--- a/templates/Dynamic/ElementalTemplates/Layout/TemplatePreviewContent.ss
+++ b/templates/Dynamic/ElementalTemplates/Layout/TemplatePreviewContent.ss
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="$ContentLocale">
+<head>
+    <% base_tag %>
+    <!-- Force desktop viewport for proper responsive breakpoints in screenshots -->
+    <meta name="viewport" content="width=1400, initial-scale=1">
+    $MetaTags(false)
+
+    <title>$Template.Title - Preview</title>
+
+    <% include Favicons %>
+    <% include Requirements %>
+    <% include FontKit %>
+    <% include CustomStyles %>
+    <style>
+        /* Screenshot capture styling */
+        body {
+            margin: 0;
+            padding: 0;
+            background: #fff;
+        }
+        .template-preview-container {
+            /* Full width to allow desktop breakpoints to apply */
+            width: 100%;
+            max-width: 1400px;
+            margin: 0 auto;
+            padding: 40px;
+            background: #fff;
+            box-sizing: border-box;
+        }
+    </style>
+</head>
+<body class="template-preview-content BlockPage">
+    <main>
+        <div class="template-preview-container" id="template-content">
+            $Page.ElementalArea
+        </div>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Adds browser-based screenshot capture functionality for template previews. This allows CMS users to generate preview images directly from the template admin, ensuring accurate visual representations of templates at desktop breakpoints.

## Changes

### New Features
- **Content-Only Preview Mode**: `TemplatePreviewController` now supports `?content_only=1` parameter for clean preview rendering without site chrome
- **Screenshot Capture Modal**: "Capture Preview Image" button in template editor opens a modal with:
  - Live iframe preview at 1400px width (lg breakpoint)
  - html2canvas-powered screenshot capture
  - Automatic upload and LayoutImage association
- **ScreenshotUploadController**: Secure endpoint for receiving base64-encoded screenshots

### Technical Details
- `TemplatePreviewContent.ss` includes theme Requirements, FontKit, and CustomStyles for proper responsive rendering
- Modal renders at 1400px width to trigger desktop CSS breakpoints (e.g., 3-column layouts)
- CSRF and permission checks on upload endpoint

## Related Issues
- Addresses #46 (content-only preview)
- Enables visual template previews for template picker (#40)

## Testing
1. Navigate to Element Templates admin
2. Edit any template
3. Click "Capture Preview Image" button
4. Verify modal shows desktop layout
5. Click "Capture Screenshot"
6. Confirm LayoutImage field updates