### PR TITLE
Fix: Resolution to CMS UI hanging on Apply Template

### DIFF
--- a/src/Extension/SiteTreeExtension.php
+++ b/src/Extension/SiteTreeExtension.php
@@ -15,6 +15,7 @@ use SilverStripe\Forms\Form;
 use SilverStripe\Forms\ToggleCompositeField;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationException;
 
 /**
  * Class \Dynamic\ElementalTemplates\Extension\SiteTreeExtension
@@ -129,17 +130,29 @@ class SiteTreeExtension extends DataExtension
     {
         $this->logAction("applyTemplate triggered", "debug");
 
+        $isAjax = Controller::has_curr() && Controller::curr()->getRequest()->isAjax();
+
         $templateID = $data['ApplyTemplateID'] ?? null;
         if (!$templateID) {
+            $message = 'Please select a template before applying.';
             $this->logAction("No template ID provided in the form data.", "warning");
-            throw new \Exception('Please select a template before applying.');
+            if ($isAjax) {
+                throw new ValidationException($message);
+            }
+            $form->sessionMessage($message, 'warning');
+            return Controller::curr()->redirectBack();
         }
 
         // Ensure the template is retrieved before passing it to the service
         $template = Template::get()->byID($templateID);
         if (!$template) {
+            $message = 'The selected template could not be found.';
             $this->logAction("No template found with ID: " . $templateID, "error");
-            throw new \Exception('The selected template could not be found.');
+            if ($isAjax) {
+                throw new ValidationException($message);
+            }
+            $form->sessionMessage($message, 'bad');
+            return Controller::curr()->redirectBack();
         }
 
         /** @var TemplateApplicator $applicator */
@@ -148,10 +161,19 @@ class SiteTreeExtension extends DataExtension
 
         if (!$result['success']) {
             $this->logAction($result['message'], "error");
-            throw new \Exception($result['message']);
+            if ($isAjax) {
+                throw new ValidationException($result['message']);
+            }
+            $form->sessionMessage($result['message'], 'bad');
+            return Controller::curr()->redirectBack();
         }
 
-        return $result['message'];
+        if ($isAjax) {
+            return $result['message'];
+        }
+
+        $form->sessionMessage($result['message'], 'good');
+        return Controller::curr()->redirectBack();
     }
 
     /**

--- a/src/Extension/SiteTreeExtension.php
+++ b/src/Extension/SiteTreeExtension.php
@@ -122,7 +122,8 @@ class SiteTreeExtension extends DataExtension
      *
      * @param array $data Form data, expecting an 'ApplyTemplateID' field.
      * @param Form $form
-     * @return \SilverStripe\Control\HTTPResponse
+     * @return string
+     * @throws \Exception
      */
     public function applyTemplate($data, Form $form)
     {
@@ -131,16 +132,14 @@ class SiteTreeExtension extends DataExtension
         $templateID = $data['ApplyTemplateID'] ?? null;
         if (!$templateID) {
             $this->logAction("No template ID provided in the form data.", "warning");
-            $form->sessionMessage('Please select a template before applying.', 'bad');
-            return Controller::curr()->redirectBack();
+            throw new \Exception('Please select a template before applying.');
         }
 
         // Ensure the template is retrieved before passing it to the service
         $template = Template::get()->byID($templateID);
         if (!$template) {
             $this->logAction("No template found with ID: " . $templateID, "error");
-            $form->sessionMessage('The selected template could not be found.', 'bad');
-            return Controller::curr()->redirectBack();
+            throw new \Exception('The selected template could not be found.');
         }
 
         /** @var TemplateApplicator $applicator */
@@ -149,12 +148,10 @@ class SiteTreeExtension extends DataExtension
 
         if (!$result['success']) {
             $this->logAction($result['message'], "error");
-            $form->sessionMessage($result['message'], 'bad');
-            return Controller::curr()->redirectBack();
+            throw new \Exception($result['message']);
         }
 
-        $form->sessionMessage($result['message'], 'good');
-        return Controller::curr()->redirectBack();
+        return $result['message'];
     }
 
     /**

--- a/src/Extension/SiteTreeExtension.php
+++ b/src/Extension/SiteTreeExtension.php
@@ -123,7 +123,8 @@ class SiteTreeExtension extends DataExtension
      *
      * @param array $data Form data, expecting an 'ApplyTemplateID' field.
      * @param Form $form
-     * @return string
+     * @return string|\SilverStripe\Control\HTTPResponse
+     * @throws \SilverStripe\ORM\ValidationException
      * @throws \Exception
      */
     public function applyTemplate($data, Form $form)

--- a/tests/Extension/CMSPageAddControllerExtensionTest.yml
+++ b/tests/Extension/CMSPageAddControllerExtensionTest.yml
@@ -18,4 +18,4 @@ Dynamic\ElementalTemplates\Tests\TestOnly\SamplePage:
 Dynamic\ElementalTemplates\Tests\TestOnly\TestTemplate:
   testTemplate:
     Title: "Test Template"
-    ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.testElementalArea
+    ElementsID: =>DNADesign\Elemental\Models\ElementalArea.testElementalArea

--- a/tests/Extension/CMSPageAddControllerExtensionTest.yml
+++ b/tests/Extension/CMSPageAddControllerExtensionTest.yml
@@ -13,7 +13,6 @@ DNADesign\Elemental\Models\ElementalArea:
 Dynamic\ElementalTemplates\Tests\TestOnly\SamplePage:
   testPage:
     Title: "Test Page"
-    ClassName: "Page"
     ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.testElementalArea
 
 Dynamic\ElementalTemplates\Tests\TestOnly\TestTemplate:

--- a/tests/Extension/SiteTreeExtensionTest.php
+++ b/tests/Extension/SiteTreeExtensionTest.php
@@ -10,6 +10,7 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\Form;
 use SilverStripe\ORM\ValidationException;
+use SilverStripe\Control\Session;
 
 class SiteTreeExtensionTest extends SapphireTest
 {
@@ -23,6 +24,12 @@ class SiteTreeExtensionTest extends SapphireTest
         TestTemplate::class,
     ];
 
+    protected static $required_extensions = [
+        SamplePage::class => [
+            \DNADesign\Elemental\Extensions\ElementalPageExtension::class,
+        ],
+    ];
+
     public function testApplyTemplateThrowsValidationExceptionOnAjax()
     {
         $page = $this->objFromFixture(SamplePage::class, 'testPage');
@@ -33,6 +40,7 @@ class SiteTreeExtensionTest extends SapphireTest
         // Mock ajax request
         $request = new HTTPRequest('POST', '/');
         $request->addHeader('X-Requested-With', 'XMLHttpRequest');
+        $request->setSession(new Session([]));
         
         $controller = new Controller();
         $controller->setRequest($request);
@@ -62,6 +70,7 @@ class SiteTreeExtensionTest extends SapphireTest
         // Mock ajax request
         $request = new HTTPRequest('POST', '/');
         $request->addHeader('X-Requested-With', 'XMLHttpRequest');
+        $request->setSession(new Session([]));
         
         $controller = new Controller();
         $controller->setRequest($request);

--- a/tests/Extension/SiteTreeExtensionTest.php
+++ b/tests/Extension/SiteTreeExtensionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Dynamic\ElementalTemplates\Tests\Extension;
+
+use Dynamic\ElementalTemplates\Extension\SiteTreeExtension;
+use Dynamic\ElementalTemplates\Tests\TestOnly\SamplePage;
+use Dynamic\ElementalTemplates\Tests\TestOnly\TestTemplate;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\Form;
+use SilverStripe\ORM\ValidationException;
+
+class SiteTreeExtensionTest extends SapphireTest
+{
+    protected static $fixture_file = 'CMSPageAddControllerExtensionTest.yml';
+
+    /**
+     * @var string[]
+     */
+    protected static $extra_dataobjects = [
+        SamplePage::class,
+        TestTemplate::class,
+    ];
+
+    public function testApplyTemplateThrowsValidationExceptionOnAjax()
+    {
+        $page = $this->objFromFixture(SamplePage::class, 'testPage');
+
+        $extension = new SiteTreeExtension();
+        $extension->setOwner($page);
+
+        // Mock ajax request
+        $request = new HTTPRequest('POST', '/');
+        $request->addHeader('X-Requested-With', 'XMLHttpRequest');
+        
+        $controller = new Controller();
+        $controller->setRequest($request);
+        $controller->pushCurrent();
+
+        $form = $this->createMock(Form::class);
+        $data = ['ApplyTemplateID' => 9999]; // non-existent
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The selected template could not be found.');
+
+        try {
+            $extension->applyTemplate($data, $form);
+        } finally {
+            $controller->popCurrent();
+        }
+    }
+
+    public function testApplyTemplateReturnsStringOnAjaxSuccess()
+    {
+        $page = $this->objFromFixture(SamplePage::class, 'testPage');
+        $template = $this->objFromFixture(TestTemplate::class, 'testTemplate');
+
+        $extension = new SiteTreeExtension();
+        $extension->setOwner($page);
+
+        // Mock ajax request
+        $request = new HTTPRequest('POST', '/');
+        $request->addHeader('X-Requested-With', 'XMLHttpRequest');
+        
+        $controller = new Controller();
+        $controller->setRequest($request);
+        $controller->pushCurrent();
+
+        $form = $this->createMock(Form::class);
+        $data = ['ApplyTemplateID' => $template->ID]; // valid existing template
+
+        try {
+            $result = $extension->applyTemplate($data, $form);
+            $this->assertIsString($result);
+        } finally {
+            $controller->popCurrent();
+        }
+    }
+}

--- a/tests/Extension/SiteTreeExtensionTest.php
+++ b/tests/Extension/SiteTreeExtensionTest.php
@@ -44,7 +44,7 @@ class SiteTreeExtensionTest extends SapphireTest
 
         $controller = new Controller();
         $controller->setRequest($request);
-        Controller::pushCurrent($controller);
+        $controller->pushCurrent();
 
         $form = $this->createMock(Form::class);
         $data = ['ApplyTemplateID' => 9999]; // non-existent
@@ -55,7 +55,7 @@ class SiteTreeExtensionTest extends SapphireTest
         try {
             $extension->applyTemplate($data, $form);
         } finally {
-            Controller::popCurrent();
+            $controller->popCurrent();
         }
     }
 
@@ -74,7 +74,7 @@ class SiteTreeExtensionTest extends SapphireTest
 
         $controller = new Controller();
         $controller->setRequest($request);
-        Controller::pushCurrent($controller);
+        $controller->pushCurrent();
 
         $form = $this->createMock(Form::class);
         $data = ['ApplyTemplateID' => $template->ID]; // valid existing template
@@ -84,7 +84,7 @@ class SiteTreeExtensionTest extends SapphireTest
             $this->assertIsString($result);
             $this->assertNotSame('', trim($result));
         } finally {
-            Controller::popCurrent();
+            $controller->popCurrent();
         }
     }
 }

--- a/tests/Extension/SiteTreeExtensionTest.php
+++ b/tests/Extension/SiteTreeExtensionTest.php
@@ -41,7 +41,7 @@ class SiteTreeExtensionTest extends SapphireTest
         $request = new HTTPRequest('POST', '/');
         $request->addHeader('X-Requested-With', 'XMLHttpRequest');
         $request->setSession(new Session([]));
-        
+
         $controller = new Controller();
         $controller->setRequest($request);
         Controller::pushCurrent($controller);
@@ -71,7 +71,7 @@ class SiteTreeExtensionTest extends SapphireTest
         $request = new HTTPRequest('POST', '/');
         $request->addHeader('X-Requested-With', 'XMLHttpRequest');
         $request->setSession(new Session([]));
-        
+
         $controller = new Controller();
         $controller->setRequest($request);
         Controller::pushCurrent($controller);
@@ -82,6 +82,7 @@ class SiteTreeExtensionTest extends SapphireTest
         try {
             $result = $extension->applyTemplate($data, $form);
             $this->assertIsString($result);
+            $this->assertNotSame('', trim($result));
         } finally {
             Controller::popCurrent();
         }

--- a/tests/Extension/SiteTreeExtensionTest.php
+++ b/tests/Extension/SiteTreeExtensionTest.php
@@ -44,7 +44,7 @@ class SiteTreeExtensionTest extends SapphireTest
         
         $controller = new Controller();
         $controller->setRequest($request);
-        $controller->pushCurrent();
+        Controller::pushCurrent($controller);
 
         $form = $this->createMock(Form::class);
         $data = ['ApplyTemplateID' => 9999]; // non-existent
@@ -55,7 +55,7 @@ class SiteTreeExtensionTest extends SapphireTest
         try {
             $extension->applyTemplate($data, $form);
         } finally {
-            $controller->popCurrent();
+            Controller::popCurrent();
         }
     }
 
@@ -74,7 +74,7 @@ class SiteTreeExtensionTest extends SapphireTest
         
         $controller = new Controller();
         $controller->setRequest($request);
-        $controller->pushCurrent();
+        Controller::pushCurrent($controller);
 
         $form = $this->createMock(Form::class);
         $data = ['ApplyTemplateID' => $template->ID]; // valid existing template
@@ -83,7 +83,7 @@ class SiteTreeExtensionTest extends SapphireTest
             $result = $extension->applyTemplate($data, $form);
             $this->assertIsString($result);
         } finally {
-            $controller->popCurrent();
+            Controller::popCurrent();
         }
     }
 }


### PR DESCRIPTION
## Description

When applying an elemental template natively via the CMS UI, the process would permanently hang visually on "Applying...", requiring a manual browser refresh to see the elements. 

This fixes a bug in `SiteTreeExtension::applyTemplate()` where returning a raw `HTTPResponse` object directly (such as `redirectBack()`) skipped the specific wrapper logic from `lekoala/silverstripe-cms-actions` that appends the required `X-Reload` header to the AJAX response.

By throwing exceptions on error states and returning the standard `message` string on success, `silverstripe-cms-actions` natively formats the response and appends the proper headers which instructs the Silverstripe JS wrapper `LeftAndMain` to automatically do a PJAX refresh of the interface, seamlessly displaying the newly imported blocks.

## Checklist
- [x] Tested manually
- [x] Verified logic behaves as described in `lekoala/silverstripe-cms-actions` documentation