### PR TITLE
fix: SS6 namespace move — ValidationException

### DIFF
--- a/src/Extension/CMSPageAddControllerExtension.php
+++ b/src/Extension/CMSPageAddControllerExtension.php
@@ -10,7 +10,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\ORM\ValidationException;
+use SilverStripe\Core\Validation\ValidationException;
 use DNADesign\Elemental\Extensions\ElementalAreasExtension;
 use Dynamic\ElementalTemplates\Models\Template;
 use Dynamic\ElementalTemplates\Service\TemplateApplicator;

--- a/src/Extension/SiteTreeExtension.php
+++ b/src/Extension/SiteTreeExtension.php
@@ -16,7 +16,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\ToggleCompositeField;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\ValidationException;
+use SilverStripe\Core\Validation\ValidationException;
 
 /**
  * Class \Dynamic\ElementalTemplates\Extension\SiteTreeExtension
@@ -125,7 +125,7 @@ class SiteTreeExtension extends Extension
      * @param array $data Form data, expecting an 'ApplyTemplateID' field.
      * @param Form $form
      * @return string|\SilverStripe\Control\HTTPResponse
-     * @throws \SilverStripe\ORM\ValidationException
+     * @throws \SilverStripe\Core\Validation\ValidationException
      * @throws \Exception
      */
     public function applyTemplate($data, Form $form)
@@ -184,7 +184,7 @@ class SiteTreeExtension extends Extension
      * @param array $data
      * @param Form $form
      * @return void
-     * @throws \SilverStripe\ORM\ValidationException
+     * @throws \SilverStripe\Core\Validation\ValidationException
      */
     public function CreateTemplate($data, $form): void
     {


### PR DESCRIPTION
## Summary
- `SilverStripe\ORM\ValidationException` → `SilverStripe\Core\Validation\ValidationException` (SiteTreeExtension, CMSPageAddControllerExtension)
- Also updated `@throws` docblock FQCNs in SiteTreeExtension to match

Class moved in SilverStripe 6. Caught by PHPStan audit across the full Essentials suite.

## Test plan
- [ ] `ddev sake dev/build flush=1` passes (verified in testbed)
- [ ] PHPStan reports no errors on these files