### PR TITLE
fix(#59): port 3 BuildTask files to SS6 branch 3

### DIFF
--- a/src/Models/Template.php
+++ b/src/Models/Template.php
@@ -30,6 +30,7 @@ use SilverStripe\SiteConfig\SiteConfig;
  * @method \DNADesign\Elemental\Models\ElementalArea Elements()
  * @method \SilverStripe\Assets\Image LayoutImage()
  * @mixin \DNADesign\Elemental\Extensions\ElementalAreasExtension
+ * @mixin \SilverStripe\Versioned\Versioned
  */
 class Template extends DataObject implements PermissionProvider
 {

--- a/src/Tasks/PublishTemplatesTask.php
+++ b/src/Tasks/PublishTemplatesTask.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Dynamic\ElementalTemplates\Tasks;
+
+use Dynamic\ElementalTemplates\Models\Template;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\PolyExecution\PolyOutput;
+use SilverStripe\Versioned\Versioned;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+
+class PublishTemplatesTask extends BuildTask
+{
+    private static $segment = 'PublishTemplatesTask';
+
+    protected string $title = 'Publish All Templates';
+
+    protected static string $description = 'Loops through all Template records and publishes them.';
+
+    protected function execute(InputInterface $input, PolyOutput $output): int
+    {
+        $templates = Template::get();
+
+        foreach ($templates as $template) {
+            if ($template->isArchived()) {
+                $template->writeToStage(Versioned::DRAFT);
+                $template->publishRecursive();
+                $output->writeln("Published Template: {$template->Title} (ID: {$template->ID})");
+            } else {
+                $output->writeln("Template already published: {$template->Title} (ID: {$template->ID})");
+            }
+        }
+
+        $output->writeln('Task completed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Tasks/SkeletonElementsPopulateTask.php
+++ b/src/Tasks/SkeletonElementsPopulateTask.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Dynamic\ElementalTemplates\Tasks;
+
+use Dynamic\ElementalTemplates\Models\Template;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\PolyExecution\PolyOutput;
+use SilverStripe\Versioned\Versioned;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+
+class SkeletonElementsPopulateTask extends BuildTask
+{
+    private static string $segment = 'SkeletonElementsPopulateTask';
+
+    protected string $title = 'Populate Template Elements';
+
+    protected static string $description = 'Populate the template elements with some default content';
+
+    protected function execute(InputInterface $input, PolyOutput $output): int
+    {
+        $populate = Template::config()->get('populate') ?? [];
+
+        foreach (Template::get() as $skeleton) {
+            $area = $skeleton->Elements();
+            foreach ($area->Elements() as $element) {
+                $output->writeln("Populating content for {$element->ClassName} with ID {$element->ID}");
+                if (array_key_exists($element->ClassName, $populate)) {
+                    foreach ($populate[$element->ClassName] as $field => $value) {
+                        $element->$field = $value;
+                    }
+
+                    $element->write();
+                    $element->writeToStage(Versioned::DRAFT);
+                }
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Tasks/UpdateBaseElementGlobalAvailabilityTask.php
+++ b/src/Tasks/UpdateBaseElementGlobalAvailabilityTask.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Dynamic\ElementalTemplates\Tasks;
+
+use DNADesign\Elemental\Models\BaseElement;
+use Dynamic\ElementalTemplates\Models\Template;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\PolyExecution\PolyOutput;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+
+class UpdateBaseElementGlobalAvailabilityTask extends BuildTask
+{
+    private static string $segment = 'UpdateBaseElementGlobalAvailabilityTask';
+
+    protected string $title = 'Update BaseElement Global Availability';
+
+    protected static string $description = 'Sets AvailableGlobally to false for BaseElements associated with Templates.';
+
+    protected function execute(InputInterface $input, PolyOutput $output): int
+    {
+        $elements = BaseElement::get();
+
+        foreach ($elements as $element) {
+            $manager = $element->getPage();
+
+            if ($manager instanceof Template) {
+                $element->AvailableGlobally = false;
+                $element->write();
+                $output->writeln("Updated AvailableGlobally for BaseElement ID: {$element->ID}");
+            } else {
+                $output->writeln(
+                    "No action taken for BaseElement ID: {$element->ID} as it is not associated with a Template."
+                );
+            }
+        }
+
+        $output->writeln('Task completed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Tasks/UpdateBaseElementGlobalAvailabilityTask.php
+++ b/src/Tasks/UpdateBaseElementGlobalAvailabilityTask.php
@@ -24,8 +24,8 @@ class UpdateBaseElementGlobalAvailabilityTask extends BuildTask
         foreach ($elements as $element) {
             $manager = $element->getPage();
 
-            if ($manager instanceof Template) {
-                $element->AvailableGlobally = false;
+            if ($manager instanceof Template && $element->hasField('AvailableGlobally')) {
+                $element->setField('AvailableGlobally', false);
                 $element->write();
                 $output->writeln("Updated AvailableGlobally for BaseElement ID: {$element->ID}");
             } else {


### PR DESCRIPTION
Closes #59.

The SS6 branch `3` was forked from a stale commit and never carried three functional BuildTasks that exist on SS5 branch `2`. This ports them with the SS6 BuildTask migration applied.

## Files added
- `src/Tasks/PublishTemplatesTask.php`
- `src/Tasks/SkeletonElementsPopulateTask.php`
- `src/Tasks/UpdateBaseElementGlobalAvailabilityTask.php`

## SS6 migration applied to each
- typed `protected string $title` / `protected static string $description`
- `run($request)` → `execute(InputInterface, PolyOutput): int` returning `Command::SUCCESS`
- `echo` → `$output->writeln()`

## Latent defects corrected from the branch-2 originals
- `SkeletonElementsPopulateTask.php` declared a class named `TemplateElementsPopulateTask` (PSR-4 mismatch — not autoloadable). Class renamed to match the filename.
- `UpdateBaseElementGlobalAvailabilityTask` used `$element->getOwner()->getPage()` (`getOwner()` is Extension-only and would fatal). Corrected to `BaseElement::getPage()`.
- Guarded `Template::config()->get('populate')` with `?? []` for PHP 8 strictness.

## Verification
- `ddev sake dev/build flush=1` → exit 0, "Database build completed!"
- All three tasks register and run without fatal:
  - `PublishTemplatesTask` → publishes/reports templates
  - `SkeletonElementsPopulateTask` → iterates template elements
  - `UpdateBaseElementGlobalAvailabilityTask` → correctly matches Template-owned elements and updates `AvailableGlobally`

Identified by the SS6 sync-gap audit (2026-06-10).