### PR TITLE
fix(#63): apply template in place instead of ejecting the editor

### DIFF
--- a/src/Extension/SiteTreeExtension.php
+++ b/src/Extension/SiteTreeExtension.php
@@ -113,6 +113,12 @@ class SiteTreeExtension extends Extension
                     $ap = CustomAction::create('ApplyTemplate', 'Apply Blocks Template')
                 );
                 $ap->setShouldRefresh(true);
+                // Pin the post-action reload to this record. Without an explicit URL,
+                // cms-actions' addXReload() falls back to the request referer, which
+                // resolves to the bare "admin/pages/edit/" (no record ID) and ejects the
+                // editor to the pages list. CMSEditLink() keeps the user on the page,
+                // refreshing in place to show the applied blocks.
+                $ap->setRedirectURL($this->owner->CMSEditLink());
             }
         }
     }

--- a/src/Service/TemplateApplicator.php
+++ b/src/Service/TemplateApplicator.php
@@ -47,11 +47,20 @@ class TemplateApplicator
 
         // Materialize the record's elemental area if it has not been created yet.
         // Newly added pages (or pages never saved with blocks) have ElementalAreaID = 0;
-        // ElementalAreasExtension::onBeforeWrite() creates the area on write, so writing
-        // the record first lets us apply the template in place instead of bailing out.
+        // ElementalAreasExtension::onBeforeWrite() creates the area on write (only while
+        // reading the DRAFT stage, which is the CMS edit context), so writing the record
+        // first lets us apply the template in place instead of bailing out. The write is
+        // guarded so a validation/hook failure keeps the method's no-throw contract
+        // instead of escaping uncaught and leaving a half-applied record.
         $elementalArea = $record->ElementalArea();
         if (!$elementalArea || !$elementalArea->exists()) {
-            $record->write();
+            try {
+                $record->write();
+            } catch (\Exception $e) {
+                $message = "Could not initialize elemental area for record ID {$record->ID}: {$e->getMessage()}";
+                $logger->error($message);
+                return ['success' => false, 'message' => $message];
+            }
             $elementalArea = $record->ElementalArea();
         }
 

--- a/src/Service/TemplateApplicator.php
+++ b/src/Service/TemplateApplicator.php
@@ -45,7 +45,16 @@ class TemplateApplicator
             return ['success' => false, 'message' => $message];
         }
 
+        // Materialize the record's elemental area if it has not been created yet.
+        // Newly added pages (or pages never saved with blocks) have ElementalAreaID = 0;
+        // ElementalAreasExtension::onBeforeWrite() creates the area on write, so writing
+        // the record first lets us apply the template in place instead of bailing out.
         $elementalArea = $record->ElementalArea();
+        if (!$elementalArea || !$elementalArea->exists()) {
+            $record->write();
+            $elementalArea = $record->ElementalArea();
+        }
+
         if (!$elementalArea || !$elementalArea->exists()) {
             $message = "Record ID {$record->ID} does not have an elemental area.";
             $logger->error($message);

--- a/tests/Extension/SiteTreeExtensionTest.php
+++ b/tests/Extension/SiteTreeExtensionTest.php
@@ -5,10 +5,15 @@ namespace Dynamic\ElementalTemplates\Tests\Extension;
 use Dynamic\ElementalTemplates\Extension\SiteTreeExtension;
 use Dynamic\ElementalTemplates\Tests\TestOnly\SamplePage;
 use Dynamic\ElementalTemplates\Tests\TestOnly\TestTemplate;
+use LeKoala\CmsActions\CustomAction;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
+use SilverStripe\Forms\LiteralField;
+use SilverStripe\Forms\Tab;
+use SilverStripe\Forms\TabSet;
 use SilverStripe\Core\Validation\ValidationException;
 use SilverStripe\Control\Session;
 
@@ -86,5 +91,40 @@ class SiteTreeExtensionTest extends SapphireTest
         } finally {
             $controller->popCurrent();
         }
+    }
+
+    public function testApplyTemplateActionRedirectsToCurrentRecord()
+    {
+        $this->logInWithPermission('ADMIN');
+
+        $page = $this->objFromFixture(SamplePage::class, 'testPage');
+
+        $extension = new SiteTreeExtension();
+        $extension->setOwner($page);
+
+        // Build the minimal ActionMenus.MoreOptions structure updateCMSActions() expects.
+        // Tab::create() signature is ($name, $title, ...$children) — the Information field
+        // must be passed as a child, not as the title.
+        $moreOptions = Tab::create('MoreOptions', 'More Options', LiteralField::create('Information', 'info'));
+        $actions = FieldList::create(TabSet::create('ActionMenus', $moreOptions));
+
+        $extension->updateCMSActions($actions);
+
+        $applyAction = null;
+        foreach ($moreOptions->getChildren() as $field) {
+            if ($field instanceof CustomAction && $field->actionName() === 'ApplyTemplate') {
+                $applyAction = $field;
+                break;
+            }
+        }
+
+        $this->assertInstanceOf(
+            CustomAction::class,
+            $applyAction,
+            'The ApplyTemplate action should be registered for an elemental page.'
+        );
+        // Without an explicit redirect URL the post-action reload falls back to the
+        // referer and ejects the editor to /admin/pages (issue #63).
+        $this->assertSame($page->CMSEditLink(), $applyAction->getRedirectURL());
     }
 }

--- a/tests/Service/TemplateApplicatorTest.php
+++ b/tests/Service/TemplateApplicatorTest.php
@@ -9,6 +9,7 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\SapphireTest;
 use DNADesign\Elemental\Models\ElementalArea;
 use Dynamic\ElementalTemplates\Tests\TestOnly\SamplePage;
+use SilverStripe\Versioned\Versioned;
 
 class TemplateApplicatorTest extends SapphireTest
 {
@@ -98,29 +99,50 @@ class TemplateApplicatorTest extends SapphireTest
         $this->assertIsString($result['message']);
     }
 
-    public function testApplyTemplateToRecordNoElementalArea()
+    public function testApplyTemplateMaterializesMissingElementalArea()
     {
         // Create test data programmatically
         $validElementalArea = ElementalArea::create();
         $validElementalArea->Title = 'Valid Elemental Area';
         $validElementalArea->write();
 
+        // Add an element so we can confirm it is duplicated into the materialized area
+        $templateElement = \DNADesign\Elemental\Models\ElementContent::create();
+        $templateElement->Title = 'Template Content Element';
+        $templateElement->HTML = '<p>This is template content</p>';
+        $templateElement->ParentID = $validElementalArea->ID;
+        $templateElement->write();
+
         $validTemplate = Template::create();
         $validTemplate->Title = 'Valid Template';
         $validTemplate->ElementsID = $validElementalArea->ID;
         $validTemplate->write();
 
+        // Apply Template runs in the CMS DRAFT context; elemental only materializes
+        // areas while reading the draft stage (allowAlteringElementalArea()).
+        Versioned::set_stage(Versioned::DRAFT);
+
+        // Persist the page, then simulate a page whose elemental area was never
+        // materialized (ElementalAreaID = 0) — issue #63. Set it in memory only so the
+        // applicator is the one that has to create the area.
         $record = SamplePage::create();
         $record->Title = 'Test Page No Elements';
-        // Do NOT write() - Page 'owns' ElementalArea, so write() would auto-create it
-        // We want to test with no ElementalAreaID to validate proper error handling
+        $record->write();
+        $record->ElementalAreaID = 0;
 
         $applicator = new TemplateApplicator();
         $result = $applicator->applyTemplateToRecord($record, $validTemplate);
 
-        // Should fail because the record doesn't support or have elemental areas
-        $this->assertFalse($result['success']);
-        $this->assertNotEmpty($result['message']);
-        $this->assertIsString($result['message']);
+        // The applicator should materialize the area and apply the template in place.
+        $this->assertTrue(
+            $result['success'],
+            'Expected the applicator to materialize the missing area, got: ' . ($result['message'] ?? 'no message')
+        );
+        $this->assertGreaterThan(0, $record->ElementalAreaID, 'Elemental area should have been created.');
+        $this->assertGreaterThan(
+            0,
+            $record->ElementalArea()->Elements()->count(),
+            'Template elements should have been duplicated into the materialized area.'
+        );
     }
 }

--- a/tests/Service/TemplateApplicatorTest.php
+++ b/tests/Service/TemplateApplicatorTest.php
@@ -145,4 +145,33 @@ class TemplateApplicatorTest extends SapphireTest
             'Template elements should have been duplicated into the materialized area.'
         );
     }
+
+    public function testApplyTemplateFailsWhenAreaCannotBeMaterialized()
+    {
+        $validElementalArea = ElementalArea::create();
+        $validElementalArea->Title = 'Valid Elemental Area';
+        $validElementalArea->write();
+
+        $validTemplate = Template::create();
+        $validTemplate->Title = 'Valid Template';
+        $validTemplate->ElementsID = $validElementalArea->ID;
+        $validTemplate->write();
+
+        // Outside the DRAFT stage the elemental area is not auto-created on write, so the
+        // applicator cannot materialize one and must return a graceful failure rather than
+        // proceeding without an area.
+        Versioned::set_stage(Versioned::LIVE);
+
+        $record = SamplePage::create();
+        $record->Title = 'Live Stage Page';
+        $record->write();
+        $record->ElementalAreaID = 0;
+
+        $applicator = new TemplateApplicator();
+        $result = $applicator->applyTemplateToRecord($record, $validTemplate);
+
+        $this->assertFalse($result['success'], 'Expected failure when the area cannot be materialized.');
+        $this->assertNotEmpty($result['message']);
+        $this->assertIsString($result['message']);
+    }
 }


### PR DESCRIPTION
Closes #63.

## Problem

Clicking **Apply Template to Page** from a page's edit form:
- redirected the CMS to `/admin/pages`, dropping the editor out of the record (reported on the success path), and
- failed with **HTTP 400** on pages whose elemental area had never been materialized (`ElementalAreaID = 0`), with the editor ejected and the template never applied (#63).

Both stem from the same flow: the `ApplyTemplate` action uses `setShouldRefresh(true)`, so cms-actions' `addXReload()` sets `X-ControllerURL` to the request **referer**, which resolves to the bare `admin/pages/edit/` (no record ID). The CMS then PJAX-reloads to the blank pages section instead of refreshing the record in place. Separately, the applicator bailed when the area didn't exist.

## Fix

- **`TemplateApplicator`** materializes a missing elemental area by writing the record first (`ElementalAreasExtension::onBeforeWrite()` creates the area) instead of returning a failure.
- **`SiteTreeExtension::updateCMSActions()`** pins the `ApplyTemplate` action's redirect to `$this->owner->CMSEditLink()`, so the post-action reload lands back on the record and refreshes in place.

## Tests

- `TemplateApplicatorTest::testApplyTemplateMaterializesMissingElementalArea` — applying to a page with `ElementalAreaID = 0` now succeeds, creates the area, and duplicates the template elements.
- `SiteTreeExtensionTest::testApplyTemplateActionRedirectsToCurrentRecord` — the registered `ApplyTemplate` action carries the record's edit link as its redirect URL.

Full module suite green (32 tests, 8 pre-existing skips).

## Manual verification (SS6 testbed)

Applied a template to a `BlockPage` with `ElementalAreaID = 0`:
- editor **stayed on** `/admin/pages/edit/show/7` (no bounce to `/admin/pages`)
- elemental area materialized (`readElements/19` → 200, previously `readElements/0` → 404)
- 3 template blocks duplicated into the page and rendered in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)