### PR TITLE
fix(#64): repair Element Templates help link in picker empty state

### DIFF
--- a/src/Form/TemplatePickerField.php
+++ b/src/Form/TemplatePickerField.php
@@ -173,7 +173,7 @@ class TemplatePickerField extends FormField
             'Templates' => $this->getTemplates(),
             'hasTemplates' => $this->hasTemplates(),
             'PageID' => $this->getPageID(),
-            'AdminURL' => AdminRootController::admin_url(),
+            'AdminURL' => AdminRootController::admin_url('elemental-templates'),
         ]);
 
         return $this->customise($properties)->renderWith(

--- a/templates/Dynamic/ElementalTemplates/Form/TemplatePickerField.ss
+++ b/templates/Dynamic/ElementalTemplates/Form/TemplatePickerField.ss
@@ -59,7 +59,7 @@
         <div class="template-picker__empty">
             <span class="font-icon-block-layout template-picker__empty-icon"></span>
             <p>No templates available.</p>
-            <p class="template-picker__empty-hint">Create templates in the <a href="{$AdminURL}elemental-templates">Element Templates</a> section.</p>
+            <p class="template-picker__empty-hint">Create templates in the <a href="{$AdminURL}">Element Templates</a> section.</p>
         </div>
     <% end_if %>
 </div>

--- a/tests/Form/TemplatePickerFieldTest.php
+++ b/tests/Form/TemplatePickerFieldTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Dynamic\ElementalTemplates\Tests\Form;
+
+use Dynamic\ElementalTemplates\Form\TemplatePickerField;
+use Dynamic\ElementalTemplates\Tests\TestOnly\SamplePage;
+use SilverStripe\Dev\SapphireTest;
+
+class TemplatePickerFieldTest extends SapphireTest
+{
+    /**
+     * @var bool
+     */
+    protected $usesDatabase = true;
+
+    /**
+     * @var string[]
+     */
+    protected static $extra_dataobjects = [
+        SamplePage::class,
+    ];
+
+    public function testEmptyStateHelpLinkIsWellFormed()
+    {
+        // A page type with no matching templates renders the empty state, whose help
+        // link points at the Element Templates admin. The URL must keep the slash
+        // between the admin root and the section (issue #64).
+        $field = TemplatePickerField::create('ApplyTemplateID', 'Select template', SamplePage::class);
+
+        $html = (string) $field->Field();
+
+        $this->assertStringContainsString('admin/elemental-templates', $html);
+        $this->assertStringNotContainsString('adminelemental-templates', $html);
+    }
+}


### PR DESCRIPTION
Closes #64.

## Problem

When no templates match the current page type, the picker's empty state shows a help link to the Element Templates admin. It rendered as `/adminelemental-templates` (404) because `AdminRootController::admin_url()` returns `"admin"` (no trailing slash) and the template concatenated `elemental-templates` directly.

## Fix

- `TemplatePickerField::Field()` now passes `AdminRootController::admin_url('elemental-templates')` as `AdminURL`.
- The template emits `{$AdminURL}` alone, producing `/admin/elemental-templates`.

## Test

`TemplatePickerFieldTest::testEmptyStateHelpLinkIsWellFormed` renders the empty state and asserts the link contains `admin/elemental-templates` and not `adminelemental-templates`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)