### PR TITLE
fix(#65): match templates by ancestor page type and treat untyped as universal

### DIFF
--- a/src/Form/TemplatePickerField.php
+++ b/src/Form/TemplatePickerField.php
@@ -4,6 +4,7 @@ namespace Dynamic\ElementalTemplates\Form;
 
 use Dynamic\ElementalTemplates\Models\Template;
 use SilverStripe\Admin\AdminRootController;
+use SilverStripe\Core\ClassInfo;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Model\List\ArrayList;
 use SilverStripe\Model\ArrayData;
@@ -99,9 +100,22 @@ class TemplatePickerField extends FormField
         $list = ArrayList::create();
         $templates = Template::get();
 
-        // Filter by page type if set
+        // Filter by page type if set. A template matches when its PageType is the
+        // current class or any ancestor of it (a template tagged "Page" applies to a
+        // "BlockPage" too), or when it has no PageType at all (untyped = applies to
+        // any page type). Filtering in PHP keeps the NULL/blank handling explicit —
+        // a `filter('PageType', ...)` query would silently exclude untyped templates.
         if ($this->pageTypeFilter) {
-            $templates = $templates->filter('PageType', $this->pageTypeFilter);
+            $ancestry = array_map('strtolower', array_values(ClassInfo::ancestry($this->pageTypeFilter)));
+            $matched = ArrayList::create();
+            foreach ($templates as $template) {
+                $pageType = $template->PageType;
+                $isUniversal = ($pageType === null || $pageType === '');
+                if ($isUniversal || in_array(strtolower($pageType), $ancestry, true)) {
+                    $matched->push($template);
+                }
+            }
+            $templates = $matched;
         }
 
         foreach ($templates as $template) {

--- a/tests/Form/TemplatePickerFieldTest.php
+++ b/tests/Form/TemplatePickerFieldTest.php
@@ -54,6 +54,19 @@ class TemplatePickerFieldTest extends SapphireTest
         $this->assertNotContains('OtherTyped', $titles);
     }
 
+    public function testNoPageTypeFilterReturnsAllTemplates()
+    {
+        $this->makeTemplate('Typed', SamplePageTwo::class);
+        $this->makeTemplate('Untyped', null);
+
+        // No page-type filter set: every template should be returned regardless of PageType.
+        $field = TemplatePickerField::create('ApplyTemplateID', 'Select template');
+        $titles = $field->getTemplates()->column('Title');
+
+        $this->assertContains('Typed', $titles);
+        $this->assertContains('Untyped', $titles);
+    }
+
     private function makeTemplate(string $title, ?string $pageType): Template
     {
         $template = Template::create();

--- a/tests/Form/TemplatePickerFieldTest.php
+++ b/tests/Form/TemplatePickerFieldTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Dynamic\ElementalTemplates\Tests\Form;
+
+use Dynamic\ElementalTemplates\Form\TemplatePickerField;
+use Dynamic\ElementalTemplates\Models\Template;
+use Dynamic\ElementalTemplates\Tests\TestOnly\SamplePage;
+use Dynamic\ElementalTemplates\Tests\TestOnly\SamplePageTwo;
+use SilverStripe\Dev\SapphireTest;
+
+class TemplatePickerFieldTest extends SapphireTest
+{
+    /**
+     * @var bool
+     */
+    protected $usesDatabase = true;
+
+    /**
+     * @var string[]
+     */
+    protected static $extra_dataobjects = [
+        SamplePage::class,
+        SamplePageTwo::class,
+    ];
+
+    public function testPageTypeFilterIncludesAncestorsAndUntypedTemplates()
+    {
+        $exact = $this->makeTemplate('Exact', SamplePage::class);
+        $ancestor = $this->makeTemplate('Ancestor', \Page::class);
+        $universal = $this->makeTemplate('Universal', null);
+        $descendant = $this->makeTemplate('Descendant', SamplePageTwo::class);
+
+        $field = TemplatePickerField::create('ApplyTemplateID', 'Select template', SamplePage::class);
+        $titles = $field->getTemplates()->column('Title');
+
+        // Exact class, an ancestor class, and untyped templates all apply.
+        $this->assertContains('Exact', $titles);
+        $this->assertContains('Ancestor', $titles);
+        $this->assertContains('Universal', $titles);
+
+        // A descendant/unrelated page type must not leak in.
+        $this->assertNotContains('Descendant', $titles);
+    }
+
+    public function testUntypedTemplateAppearsForAnyPageType()
+    {
+        $this->makeTemplate('Universal', null);
+        $this->makeTemplate('OtherTyped', SamplePageTwo::class);
+
+        $field = TemplatePickerField::create('ApplyTemplateID', 'Select template', SamplePage::class);
+        $titles = $field->getTemplates()->column('Title');
+
+        $this->assertContains('Universal', $titles);
+        $this->assertNotContains('OtherTyped', $titles);
+    }
+
+    private function makeTemplate(string $title, ?string $pageType): Template
+    {
+        $template = Template::create();
+        $template->Title = $title;
+        $template->PageType = $pageType;
+        $template->write();
+
+        return $template;
+    }
+}


### PR DESCRIPTION
Closes #65.

## Problem

`TemplatePickerField::getTemplates()` filtered with an exact `filter('PageType', $class)`, so:
- a template created from one page class never showed on a parent/sibling class, and
- untyped templates (blank/`NULL` `PageType`) were excluded everywhere.

## Fix

A template now matches when its `PageType` is the current page class **or any ancestor of it** (a template tagged `Page` applies to a `BlockPage`), or when it has **no `PageType`** (untyped = applies to any type). Filtering is done in PHP via `ClassInfo::ancestry()` so `NULL`/blank handling is explicit — a `DataList` filter would silently drop untyped rows.

## Tests

`TemplatePickerFieldTest` covers ancestor match, exact match, untyped (universal), and exclusion of descendant/unrelated page types.

## Manual verification (SS6 testbed)

On a `BlockPage`, the picker now lists all 18 templates — the 14 `BlockPage`-tagged plus the 4 untyped seed templates that were previously hidden (was 14, now 18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)