### PR TITLE
feat(#80): template categories with grouped pickers

### DIFF
--- a/client/dist/styles/template-picker.css
+++ b/client/dist/styles/template-picker.css
@@ -39,6 +39,24 @@
 }
 
 /* ============================================
+   Category Group Headings
+   ============================================ */
+.template-picker__group-title {
+    margin: 0.5rem 0 0;
+    padding-bottom: 0.25rem;
+    border-bottom: 1px solid #e8eaec;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #4b5563;
+}
+
+.template-picker__group-title:first-child {
+    margin-top: 0;
+}
+
+/* ============================================
    Card Styles - Horizontal layout
    ============================================ */
 .template-picker__card {
@@ -356,6 +374,11 @@
     .template-picker__grid {
         background: #1a1a1a;
         border-color: #444;
+    }
+
+    .template-picker__group-title {
+        border-color: #444;
+        color: #aaa;
     }
 
     .template-picker__actions {

--- a/src/Extension/CMSPageAddControllerExtension.php
+++ b/src/Extension/CMSPageAddControllerExtension.php
@@ -7,7 +7,7 @@ use SilverStripe\Forms\Form;
 use SilverStripe\Core\Extension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\GroupedDropdownField;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Validation\ValidationException;
@@ -30,10 +30,13 @@ class CMSPageAddControllerExtension extends Extension
      */
     public function updatePageOptions(FieldList $fields): void
     {
-        $templates = ['' => 'Select template'] + Template::get()->map('ID', 'Title')->toArray();
-
         $title = '<span class="step-label"><span class="flyout">Step 3. </span><span class="title">(Optional) Select template to create page with</span></span>';
-        $templateField = DropdownField::create('TemplateID', DBField::create_field('HTMLFragment', $title), $templates);
+        $templateField = GroupedDropdownField::create(
+            'TemplateID',
+            DBField::create_field('HTMLFragment', $title),
+            Template::getGroupedTemplateMap()
+        );
+        $templateField->setEmptyString('Select template');
         $fields->insertAfter('PageType', $templateField);
     }
 

--- a/src/Form/TemplatePickerField.php
+++ b/src/Form/TemplatePickerField.php
@@ -91,12 +91,37 @@ class TemplatePickerField extends FormField
     }
 
     /**
-     * Get templates as an ArrayList for use in templates
+     * @var ArrayList|null Memoised result of getTemplates(); cleared on setValue().
+     */
+    protected ?ArrayList $templatesCache = null;
+
+    /**
+     * Reset the memoised template list when the field value changes, so the
+     * IsSelected flags stay in sync with the selection.
+     *
+     * @param mixed $value
+     * @param mixed $data
+     * @return $this
+     */
+    public function setValue($value, $data = null)
+    {
+        $this->templatesCache = null;
+        return parent::setValue($value, $data);
+    }
+
+    /**
+     * Get templates as an ArrayList for use in templates. Memoised because a
+     * single render calls this from getGroupedTemplates() and hasTemplates(),
+     * and each pass runs a query plus per-template image scaling.
      *
      * @return ArrayList
      */
     public function getTemplates(): ArrayList
     {
+        if ($this->templatesCache !== null) {
+            return $this->templatesCache;
+        }
+
         $list = ArrayList::create();
         $templates = Template::get();
 
@@ -141,56 +166,30 @@ class TemplatePickerField extends FormField
             ]));
         }
 
-        return $list;
+        return $this->templatesCache = $list;
     }
 
     /**
-     * Templates grouped by Category for rendering. Groups follow the configured
-     * category order, categories missing from the config follow them, and
-     * uncategorised templates come last. When no template has a category the
-     * single group has a blank Title so the field renders as a flat list with
-     * no group headings.
+     * Templates grouped by Category for rendering, via the shared
+     * {@see Template::groupByCategory()} algorithm so grouping matches the
+     * page-add dropdown exactly. When no template has a category the single
+     * group has a blank Title so the field renders as a flat, heading-less list.
      *
      * @return ArrayList
      */
     public function getGroupedTemplates(): ArrayList
     {
-        $templates = $this->getTemplates();
-
-        $grouped = [];
-        foreach (array_keys(Template::getTemplateCategories()) as $category) {
-            $grouped[$category] = ArrayList::create();
-        }
-        $uncategorised = ArrayList::create();
-
-        foreach ($templates as $template) {
-            $category = (string) $template->Category;
-            if ($category === '') {
-                $uncategorised->push($template);
-                continue;
-            }
-            if (!isset($grouped[$category])) {
-                $grouped[$category] = ArrayList::create();
-            }
-            $grouped[$category]->push($template);
-        }
+        $grouped = Template::groupByCategory($this->getTemplates());
 
         $groups = ArrayList::create();
-        foreach ($grouped as $category => $list) {
-            if ($list->count()) {
-                $groups->push(ArrayData::create([
-                    'Title' => $category,
-                    'Templates' => $list,
-                ]));
+        foreach ($grouped as $category => $templates) {
+            $list = ArrayList::create();
+            foreach ($templates as $template) {
+                $list->push($template);
             }
-        }
-
-        if ($uncategorised->count()) {
-            // Label the group only when it sits alongside categorised groups; an
-            // all-uncategorised library renders as a flat, heading-less list.
             $groups->push(ArrayData::create([
-                'Title' => $groups->count() ? 'Other' : '',
-                'Templates' => $uncategorised,
+                'Title' => $category,
+                'Templates' => $list,
             ]));
         }
 
@@ -238,7 +237,6 @@ class TemplatePickerField extends FormField
     public function Field($properties = [])
     {
         $properties = array_merge($properties, [
-            'Templates' => $this->getTemplates(),
             'GroupedTemplates' => $this->getGroupedTemplates(),
             'hasTemplates' => $this->hasTemplates(),
             'PageID' => $this->getPageID(),

--- a/src/Form/TemplatePickerField.php
+++ b/src/Form/TemplatePickerField.php
@@ -131,6 +131,7 @@ class TemplatePickerField extends FormField
             $list->push(ArrayData::create([
                 'ID' => $template->ID,
                 'Title' => $template->Title,
+                'Category' => trim((string) $template->Category),
                 'Description' => $template->dbObject('Description'),
                 'HasThumbnail' => (bool) $thumbnailUrl,
                 'ThumbnailURL' => $thumbnailUrl,
@@ -141,6 +142,59 @@ class TemplatePickerField extends FormField
         }
 
         return $list;
+    }
+
+    /**
+     * Templates grouped by Category for rendering. Groups follow the configured
+     * category order, categories missing from the config follow them, and
+     * uncategorised templates come last. When no template has a category the
+     * single group has a blank Title so the field renders as a flat list with
+     * no group headings.
+     *
+     * @return ArrayList
+     */
+    public function getGroupedTemplates(): ArrayList
+    {
+        $templates = $this->getTemplates();
+
+        $grouped = [];
+        foreach (array_keys(Template::getTemplateCategories()) as $category) {
+            $grouped[$category] = ArrayList::create();
+        }
+        $uncategorised = ArrayList::create();
+
+        foreach ($templates as $template) {
+            $category = (string) $template->Category;
+            if ($category === '') {
+                $uncategorised->push($template);
+                continue;
+            }
+            if (!isset($grouped[$category])) {
+                $grouped[$category] = ArrayList::create();
+            }
+            $grouped[$category]->push($template);
+        }
+
+        $groups = ArrayList::create();
+        foreach ($grouped as $category => $list) {
+            if ($list->count()) {
+                $groups->push(ArrayData::create([
+                    'Title' => $category,
+                    'Templates' => $list,
+                ]));
+            }
+        }
+
+        if ($uncategorised->count()) {
+            // Label the group only when it sits alongside categorised groups; an
+            // all-uncategorised library renders as a flat, heading-less list.
+            $groups->push(ArrayData::create([
+                'Title' => $groups->count() ? 'Other' : '',
+                'Templates' => $uncategorised,
+            ]));
+        }
+
+        return $groups;
     }
 
     /**
@@ -185,6 +239,7 @@ class TemplatePickerField extends FormField
     {
         $properties = array_merge($properties, [
             'Templates' => $this->getTemplates(),
+            'GroupedTemplates' => $this->getGroupedTemplates(),
             'hasTemplates' => $this->hasTemplates(),
             'PageID' => $this->getPageID(),
             'AdminURL' => AdminRootController::admin_url('elemental-templates'),

--- a/src/Models/Template.php
+++ b/src/Models/Template.php
@@ -59,7 +59,27 @@ class Template extends DataObject implements PermissionProvider
     private static array $db = [
         'Title' => 'Varchar',
         'PageType' => 'Varchar',
+        'Category' => 'Varchar',
         'Description' => 'HTMLText',
+    ];
+
+    /**
+     * Category options offered in the CMS and used to group template pickers.
+     * Projects can override or extend this list via YAML config.
+     *
+     * @var array|string[]
+     * @config
+     */
+    private static array $template_categories = [
+        'Heroes',
+        'Cards & Grids',
+        'Content',
+        'Social Proof',
+        'Conversion',
+        'People',
+        'Contact & Location',
+        'Listings',
+        'Page Layouts',
     ];
 
     /**
@@ -111,8 +131,18 @@ class Template extends DataObject implements PermissionProvider
     private static array $summary_fields = [
         'LayoutImageThumbnail' => 'Preview Image',
         'Title' => 'Name',
+        'Category' => 'Category',
         'PageTypeName' => 'Page Type',
         'ElementCount' => 'Blocks',
+    ];
+
+    /**
+     * @var array|string[]
+     * @config
+     */
+    private static array $searchable_fields = [
+        'Title',
+        'Category',
     ];
 
     /**
@@ -170,6 +200,13 @@ class Template extends DataObject implements PermissionProvider
 
             $pt->setEmptyString('Please choose...');
             $pt->setRightTitle('This will determine which elements are possible to add to the template');
+
+            $fields->replaceField(
+                'Category',
+                DropdownField::create('Category', 'Category', static::getTemplateCategories())
+                    ->setEmptyString('None')
+                    ->setRightTitle('Groups this template in the template pickers')
+            );
 
             if ($this->isinDB()) {
                 $fields->replaceField('PageType', $pt->performReadonlyTransformation());
@@ -234,17 +271,72 @@ class Template extends DataObject implements PermissionProvider
     }
 
     /**
+     * Configured category options as a value => label map.
+     *
+     * @return array<string, string>
+     */
+    public static function getTemplateCategories(): array
+    {
+        $map = [];
+
+        foreach ((array) static::config()->get('template_categories') as $category) {
+            $map[$category] = $category;
+        }
+
+        return $map;
+    }
+
+    /**
+     * All templates grouped by Category, for grouped dropdown sources. Groups
+     * follow the configured category order; categories not in the config follow
+     * them, and uncategorised templates come last under $fallbackLabel.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public static function getGroupedTemplateMap(string $fallbackLabel = 'Other'): array
+    {
+        $groups = [];
+        foreach (array_keys(static::getTemplateCategories()) as $category) {
+            $groups[$category] = [];
+        }
+
+        $uncategorised = [];
+        foreach (static::get() as $template) {
+            $category = trim((string) $template->Category);
+            if ($category === '') {
+                $uncategorised[$template->ID] = $template->Title;
+                continue;
+            }
+            $groups[$category][$template->ID] = $template->Title;
+        }
+
+        $groups = array_filter($groups);
+        if ($uncategorised) {
+            $groups[$fallbackLabel] = $uncategorised;
+        }
+
+        return $groups;
+    }
+
+    /**
      * @return mixed
      */
     protected function getAllowedTypes()
     {
         $pageType = $this->PageType;
 
+        // Untyped templates apply to any page type, so offer the base Page's
+        // elemental types rather than nothing.
         if (!$pageType || !class_exists($pageType)) {
-            return []; // Return an empty array if PageType is invalid
+            $pageType = \Page::class;
         }
 
-        return $pageType::singleton()->getElementalTypes();
+        $singleton = $pageType::singleton();
+        if (!$singleton->hasMethod('getElementalTypes')) {
+            return [];
+        }
+
+        return $singleton->getElementalTypes();
     }
 
     /**

--- a/src/Models/Template.php
+++ b/src/Models/Template.php
@@ -25,6 +25,7 @@ use SilverStripe\SiteConfig\SiteConfig;
  *
  * @property string $Title
  * @property string $PageType
+ * @property string $Category
  * @property int $ElementsID
  * @property int $LayoutImageID
  * @method ElementalArea Elements()
@@ -65,7 +66,12 @@ class Template extends DataObject implements PermissionProvider
 
     /**
      * Category options offered in the CMS and used to group template pickers.
-     * Projects can override or extend this list via YAML config.
+     *
+     * This is a numerically-indexed list, so SilverStripe config merging
+     * appends project YAML entries to these defaults rather than replacing
+     * them. To remove or reorder the defaults, first reset the config (an
+     * empty `template_categories: null` document) and then declare the full
+     * list.
      *
      * @var array|string[]
      * @config
@@ -287,13 +293,25 @@ class Template extends DataObject implements PermissionProvider
     }
 
     /**
-     * All templates grouped by Category, for grouped dropdown sources. Groups
-     * follow the configured category order; categories not in the config follow
-     * them, and uncategorised templates come last under $fallbackLabel.
+     * Group an iterable of template records (or view models exposing Category /
+     * ID / Title) into an ordered map of category label => list-of-items. The
+     * single grouping algorithm shared by both the page-add dropdown and the
+     * visual picker so they can never disagree on the same data:
      *
-     * @return array<string, array<int, string>>
+     *  - configured categories first, in `template_categories` order (empty
+     *    ones dropped),
+     *  - categories present in data but not configured, after those,
+     *  - uncategorised items merged into `$fallbackLabel` — merging into a real
+     *    configured "Other" group rather than overwriting it.
+     *
+     * When every item is uncategorised the result is a single group keyed by
+     * the empty string, so callers can render a flat, heading-less list.
+     *
+     * @param iterable $items
+     * @param string $fallbackLabel
+     * @return array<string, array<int, object>> ordered; a sole '' key = flat
      */
-    public static function getGroupedTemplateMap(string $fallbackLabel = 'Other'): array
+    public static function groupByCategory(iterable $items, string $fallbackLabel = 'Other'): array
     {
         $groups = [];
         foreach (array_keys(static::getTemplateCategories()) as $category) {
@@ -301,21 +319,60 @@ class Template extends DataObject implements PermissionProvider
         }
 
         $uncategorised = [];
-        foreach (static::get() as $template) {
-            $category = trim((string) $template->Category);
+        foreach ($items as $item) {
+            $category = trim((string) $item->Category);
             if ($category === '') {
-                $uncategorised[$template->ID] = $template->Title;
+                $uncategorised[] = $item;
                 continue;
             }
-            $groups[$category][$template->ID] = $template->Title;
+            $groups[$category][] = $item;
         }
 
         $groups = array_filter($groups);
+
         if ($uncategorised) {
-            $groups[$fallbackLabel] = $uncategorised;
+            if (!$groups) {
+                // Nothing is categorised: render flat, with no heading.
+                return ['' => $uncategorised];
+            }
+            // Append (never overwrite) so a real "Other" category keeps its own.
+            $groups[$fallbackLabel] = array_merge($groups[$fallbackLabel] ?? [], $uncategorised);
         }
 
         return $groups;
+    }
+
+    /**
+     * All templates grouped by Category as a GroupedDropdownField source. Uses
+     * {@see self::groupByCategory()} so ordering/fallback matches the visual
+     * picker. When no template is categorised a flat id => title map is
+     * returned (scalar values render as ungrouped options).
+     *
+     * @return array<string, array<int, string>>|array<int, string>
+     */
+    public static function getGroupedTemplateMap(string $fallbackLabel = 'Other'): array
+    {
+        $grouped = static::groupByCategory(static::get(), $fallbackLabel);
+
+        // Sole '' key => no categories in play: flat, ungrouped options.
+        if (array_keys($grouped) === ['']) {
+            $flat = [];
+            foreach ($grouped[''] as $template) {
+                $flat[$template->ID] = $template->Title;
+            }
+            return $flat;
+        }
+
+        $source = [];
+        foreach ($grouped as $category => $templates) {
+            $options = [];
+            foreach ($templates as $template) {
+                $options[$template->ID] = $template->Title;
+            }
+            $source[$category] = $options;
+        }
+
+        return $source;
     }
 
     /**
@@ -325,10 +382,20 @@ class Template extends DataObject implements PermissionProvider
     {
         $pageType = $this->PageType;
 
+        // A non-empty but unresolvable PageType is stale/misconfigured data;
+        // return nothing so it surfaces rather than being silently masked.
+        if ($pageType && !class_exists($pageType)) {
+            return [];
+        }
+
         // Untyped templates apply to any page type, so offer the base Page's
         // elemental types rather than nothing.
-        if (!$pageType || !class_exists($pageType)) {
+        if (!$pageType) {
             $pageType = \Page::class;
+        }
+
+        if (!class_exists($pageType)) {
+            return [];
         }
 
         $singleton = $pageType::singleton();

--- a/templates/Dynamic/ElementalTemplates/Form/TemplatePickerField.ss
+++ b/templates/Dynamic/ElementalTemplates/Form/TemplatePickerField.ss
@@ -2,14 +2,18 @@
     <% if $hasTemplates %>
         <%-- Full-width scrollable template list --%>
         <div class="template-picker__grid">
-            <% loop $Templates %>
-                <label class="template-picker__card<% if $IsSelected %> template-picker__card--selected<% end_if %>" 
-                       for="{$Up.ID}_template_{$ID}"
+            <% loop $GroupedTemplates %>
+                <% if $Title %>
+                    <h4 class="template-picker__group-title">$Title</h4>
+                <% end_if %>
+                <% loop $Templates %>
+                <label class="template-picker__card<% if $IsSelected %> template-picker__card--selected<% end_if %>"
+                       for="{$Top.ID}_template_{$ID}"
                        data-template-id="$ID"
                        tabindex="0">
-                    <input type="radio" 
-                           id="{$Up.ID}_template_{$ID}"
-                           name="$Up.Name" 
+                    <input type="radio"
+                           id="{$Top.ID}_template_{$ID}"
+                           name="$Top.Name"
                            value="$ID"
                            class="template-picker__radio"
                            <% if $IsSelected %>checked<% end_if %> />
@@ -35,13 +39,14 @@
                             <div class="template-picker__description">$Description.LimitCharacters(120)</div>
                         <% end_if %>
                         <span class="template-picker__meta">$ElementCount block<% if $ElementCount != 1 %>s<% end_if %></span>
-                        <a href="$PreviewLink" 
+                        <a href="$PreviewLink"
                            class="template-picker__preview-link"
                            title="Preview template">
                             <span class="font-icon-eye"></span> Preview
                         </a>
                     </div>
                 </label>
+                <% end_loop %>
             <% end_loop %>
         </div>
         

--- a/tests/Extension/CMSPageAddControllerExtensionTest.php
+++ b/tests/Extension/CMSPageAddControllerExtensionTest.php
@@ -47,6 +47,27 @@ class CMSPageAddControllerExtensionTest extends SapphireTest
         Injector::inst()->registerService($mockLogger, LoggerInterface::class);
     }
 
+    public function testUpdatePageOptionsAddsGroupedTemplateDropdown(): void
+    {
+        $template = $this->objFromFixture(TestTemplate::class, 'testTemplate');
+        $template->Category = 'Heroes';
+        $template->write();
+
+        $fields = new \SilverStripe\Forms\FieldList(
+            new \SilverStripe\Forms\HiddenField('PageType')
+        );
+
+        $extension = new CMSPageAddControllerExtension();
+        $extension->updatePageOptions($fields);
+
+        $field = $fields->dataFieldByName('TemplateID');
+        $this->assertInstanceOf(\SilverStripe\Forms\GroupedDropdownField::class, $field);
+
+        $source = $field->getSource();
+        $this->assertArrayHasKey('Heroes', $source);
+        $this->assertContains($template->Title, $source['Heroes']);
+    }
+
     public function testFindOrCreateElementalArea(): void
     {
         // Create a mock page with ElementalAreasExtension

--- a/tests/Form/TemplatePickerFieldTest.php
+++ b/tests/Form/TemplatePickerFieldTest.php
@@ -67,6 +67,46 @@ class TemplatePickerFieldTest extends SapphireTest
         $this->assertContains('Untyped', $titles);
     }
 
+    public function testGroupedTemplatesFollowConfiguredCategoryOrder()
+    {
+        // Created out of configured order on purpose; groups must come back in
+        // the template_categories order with uncategorised templates last.
+        $this->makeTemplate('Band', null, 'Conversion');
+        $this->makeTemplate('Hero', null, 'Heroes');
+        $this->makeTemplate('Loose', null, null);
+
+        $field = TemplatePickerField::create('ApplyTemplateID', 'Select template');
+        $groups = $field->getGroupedTemplates();
+
+        $this->assertEquals(['Heroes', 'Conversion', 'Other'], $groups->column('Title'));
+        $this->assertEquals(['Loose'], $groups->last()->Templates->column('Title'));
+    }
+
+    public function testUnknownCategoryGroupsAfterConfiguredOnes()
+    {
+        $this->makeTemplate('Custom', null, 'Bespoke Category');
+        $this->makeTemplate('Hero', null, 'Heroes');
+
+        $field = TemplatePickerField::create('ApplyTemplateID', 'Select template');
+        $groups = $field->getGroupedTemplates();
+
+        $this->assertEquals(['Heroes', 'Bespoke Category'], $groups->column('Title'));
+    }
+
+    public function testAllUncategorisedRendersSingleUnlabelledGroup()
+    {
+        $this->makeTemplate('One', null, null);
+        $this->makeTemplate('Two', null, null);
+
+        $field = TemplatePickerField::create('ApplyTemplateID', 'Select template');
+        $groups = $field->getGroupedTemplates();
+
+        // A library with no categories renders flat: one group, no heading.
+        $this->assertEquals(1, $groups->count());
+        $this->assertSame('', $groups->first()->Title);
+        $this->assertEquals(2, $groups->first()->Templates->count());
+    }
+
     public function testEmptyStateHelpLinkIsWellFormed()
     {
         // A page type with no matching templates renders the empty state, whose help
@@ -80,11 +120,12 @@ class TemplatePickerFieldTest extends SapphireTest
         $this->assertStringNotContainsString('adminelemental-templates', $html);
     }
 
-    private function makeTemplate(string $title, ?string $pageType): Template
+    private function makeTemplate(string $title, ?string $pageType, ?string $category = null): Template
     {
         $template = Template::create();
         $template->Title = $title;
         $template->PageType = $pageType;
+        $template->Category = $category;
         $template->write();
 
         return $template;

--- a/tests/Form/TemplatePickerFieldTest.php
+++ b/tests/Form/TemplatePickerFieldTest.php
@@ -93,6 +93,24 @@ class TemplatePickerFieldTest extends SapphireTest
         $this->assertEquals(['Heroes', 'Bespoke Category'], $groups->column('Title'));
     }
 
+    public function testRealOtherCategoryDoesNotDuplicateHeading()
+    {
+        Template::config()->set('template_categories', ['Heroes', 'Other']);
+
+        $this->makeTemplate('Hero', null, 'Heroes');
+        $this->makeTemplate('RealOther', null, 'Other');
+        $this->makeTemplate('Loose', null, null);
+
+        $field = TemplatePickerField::create('ApplyTemplateID', 'Select template');
+        $titles = $field->getGroupedTemplates()->column('Title');
+
+        // Exactly one "Other" group — the uncategorised template merges into the
+        // real category rather than spawning a second identically-titled group.
+        $this->assertSame(['Heroes', 'Other'], $titles);
+        $other = $field->getGroupedTemplates()->find('Title', 'Other');
+        $this->assertEquals(['RealOther', 'Loose'], $other->Templates->column('Title'));
+    }
+
     public function testAllUncategorisedRendersSingleUnlabelledGroup()
     {
         $this->makeTemplate('One', null, null);

--- a/tests/Models/TemplateTest.php
+++ b/tests/Models/TemplateTest.php
@@ -101,6 +101,71 @@ class TemplateTest extends SapphireTest
     }
 
     /**
+     * An untyped template must fall back to the base Page's elemental types so
+     * it stays editable in the CMS instead of allowing nothing.
+     *
+     * @return void
+     * @throws ReflectionException
+     */
+    public function testUntypedTemplateFallsBackToBasePageElementalTypes(): void
+    {
+        $template = Template::create();
+        $template->Title = 'Untyped';
+        $template->write();
+
+        $method = new ReflectionMethod($template, 'getAllowedTypes');
+        $method->setAccessible(true);
+        $allowed = $method->invoke($template);
+
+        $this->assertEquals(\Page::singleton()->getElementalTypes(), $allowed);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetTemplateCategoriesReturnsConfiguredMap(): void
+    {
+        Template::config()->set('template_categories', ['Heroes', 'Conversion']);
+
+        $this->assertSame(
+            ['Heroes' => 'Heroes', 'Conversion' => 'Conversion'],
+            Template::getTemplateCategories()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGroupedTemplateMapOrdersAndFallsBack(): void
+    {
+        Template::config()->set('template_categories', ['Heroes', 'Conversion']);
+
+        $make = function (string $title, ?string $category): Template {
+            $template = Template::create();
+            $template->Title = $title;
+            $template->Category = $category;
+            $template->write();
+            return $template;
+        };
+
+        $band = $make('Band', 'Conversion');
+        $hero = $make('Hero', 'Heroes');
+        $custom = $make('Custom', 'Bespoke');
+        $loose = $make('Loose', null);
+
+        $map = Template::getGroupedTemplateMap();
+
+        // Configured order first, unknown categories after, uncategorised last.
+        $this->assertSame(['Heroes', 'Conversion', 'Bespoke', 'Other'], array_keys($map));
+        $this->assertSame([$hero->ID => 'Hero'], $map['Heroes']);
+        $this->assertSame([$band->ID => 'Band'], $map['Conversion']);
+        $this->assertSame([$custom->ID => 'Custom'], $map['Bespoke']);
+        // Fixture-file templates are uncategorised too, so just assert membership.
+        $this->assertArrayHasKey($loose->ID, $map['Other']);
+        $this->assertSame('Loose', $map['Other'][$loose->ID]);
+    }
+
+    /**
      * @return void
      */
     public function testCanCreate(): void

--- a/tests/Models/TemplateTest.php
+++ b/tests/Models/TemplateTest.php
@@ -121,6 +121,26 @@ class TemplateTest extends SapphireTest
     }
 
     /**
+     * A non-empty but unresolvable PageType is stale data and must surface as
+     * "no allowed types", not be masked by the untyped fallback.
+     *
+     * @return void
+     * @throws ReflectionException
+     */
+    public function testStalePageTypeReturnsNoAllowedTypes(): void
+    {
+        $template = Template::create();
+        $template->Title = 'Stale';
+        $template->PageType = 'App\\NoSuchPageClass';
+        $template->write();
+
+        $method = new ReflectionMethod($template, 'getAllowedTypes');
+        $method->setAccessible(true);
+
+        $this->assertSame([], $method->invoke($template));
+    }
+
+    /**
      * @return void
      */
     public function testGetTemplateCategoriesReturnsConfiguredMap(): void
@@ -163,6 +183,54 @@ class TemplateTest extends SapphireTest
         // Fixture-file templates are uncategorised too, so just assert membership.
         $this->assertArrayHasKey($loose->ID, $map['Other']);
         $this->assertSame('Loose', $map['Other'][$loose->ID]);
+    }
+
+    /**
+     * With no template categorised, the dropdown source is a flat id => title
+     * map (scalar values) rather than a single pointless "Other" optgroup.
+     *
+     * @return void
+     */
+    public function testGroupedTemplateMapIsFlatWhenNoCategories(): void
+    {
+        // Only the uncategorised fixture-file templates exist here.
+        $map = Template::getGroupedTemplateMap();
+
+        $this->assertNotEmpty($map);
+        foreach ($map as $value) {
+            $this->assertIsString($value, 'Flat map values should be titles, not group arrays');
+        }
+    }
+
+    /**
+     * A real "Other" category and the uncategorised fallback must merge into a
+     * single group, never overwrite each other (the key-collision bug).
+     *
+     * @return void
+     */
+    public function testRealOtherCategoryMergesWithUncategorised(): void
+    {
+        Template::config()->set('template_categories', ['Heroes', 'Other']);
+
+        $make = function (string $title, ?string $category): Template {
+            $template = Template::create();
+            $template->Title = $title;
+            $template->Category = $category;
+            $template->write();
+            return $template;
+        };
+
+        $hero = $make('Hero', 'Heroes');
+        $realOther = $make('RealOther', 'Other');
+        $loose = $make('Loose', null);
+
+        $map = Template::getGroupedTemplateMap();
+
+        $this->assertArrayHasKey('Other', $map);
+        // Both the explicitly-categorised and the uncategorised template survive.
+        $this->assertArrayHasKey($realOther->ID, $map['Other']);
+        $this->assertArrayHasKey($loose->ID, $map['Other']);
+        $this->assertArrayHasKey($hero->ID, $map['Heroes']);
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a `Category` taxonomy to element templates so the two pickers can group them the way Genesis Blocks / Gutenberg / Elementor group their pattern libraries. Groundwork for the `recipe-silverstripe-essentials-fixtures` library redesign.

- **`Category` field** on `Template` with a configurable `template_categories` option list (defaults: Heroes, Cards & Grids, Content, Social Proof, Conversion, People, Contact & Location, Listings, Page Layouts). CMS dropdown, admin summary column + search filter.
- **Grouped page-add dropdown** — the "Step 3" template selector is now a `GroupedDropdownField` grouped by category.
- **Grouped visual picker** — `TemplatePickerField` renders category headings; a library with no categories still renders as a flat list.
- **Untyped-template fallback** — `getAllowedTypes()` falls back to the base `Page` elemental types for genuinely untyped templates so they stay editable, while a non-empty but unresolvable `PageType` still returns `[]` (stale data surfaces rather than being masked).

Both pickers share one grouping algorithm (`Template::groupByCategory()`) so they can never disagree on the same data.

## Testing

- `vendor/bin/phpunit` — 48 tests, all pass (8 new)
- `phpcs` clean, `phpstan` clean on changed files
- High-effort `/code-review` run; all confirmed findings fixed (key-collision merge, stale-PageType masking, config-append docs, redundant query passes) with regression tests

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)