### PR TITLE
fix: preview untyped templates instead of 500

### DIFF
--- a/src/Controller/TemplatePreviewController.php
+++ b/src/Controller/TemplatePreviewController.php
@@ -32,7 +32,12 @@ class TemplatePreviewController extends \PageController
             return $this->httpError(404, 'Template not found');
         }
 
+        // Untyped templates apply to any page type, so preview them against the
+        // base Page rather than 500ing — mirrors Template::getAllowedTypes().
         $pageType = $template->PageType;
+        if (!$pageType || !class_exists($pageType)) {
+            $pageType = \Page::class;
+        }
         if (!class_exists($pageType)) {
             return $this->httpError(500, 'Invalid Page Type');
         }

--- a/tests/Controller/TemplatePreviewControllerTest.php
+++ b/tests/Controller/TemplatePreviewControllerTest.php
@@ -18,21 +18,42 @@ class TemplatePreviewControllerTest extends FunctionalTest
         $this->logInWithPermission('ADMIN');
     }
 
-    public function testTemplatePreviewPageLoadsSuccessfully()
+    public function testContentOnlyPreviewRendersForTypedTemplate()
     {
-        $this->markTestSkipped('Skipping test for TemplatePreviewController as it requires a valid template ID.');
-        $template = $this->objFromFixture(Template::class, 'exampleTemplate');
-        $response = $this->get('template-preview/' . $template->ID);
+        $template = $this->makeTemplate('Typed Template', \Page::class);
+        $response = $this->get('template-preview/' . $template->ID . '?content_only=1');
 
-        $this->assertEquals(200, $response->getStatusCode(), 'Preview page should load successfully.');
-        $this->assertStringContainsString($template->Title, $response->getBody(), 'Preview page should contain the template title.');
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testContentOnlyPreviewRendersForUntypedTemplate()
+    {
+        // A template with no PageType must preview against the base Page rather
+        // than 500ing (previously "Invalid Page Type"). Regression guard for the
+        // untyped-template support added alongside the Category feature.
+        $template = $this->makeTemplate('Untyped Template', null);
+        $response = $this->get('template-preview/' . $template->ID . '?content_only=1');
+
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     public function testTemplatePreviewPageNotFound()
     {
-        $this->markTestSkipped('Skipping test for TemplatePreviewController as it requires a valid template ID.');
         $response = $this->get('template-preview/99999'); // Non-existent ID
 
         $this->assertEquals(404, $response->getStatusCode(), 'Non-existent template should return 404.');
+    }
+
+    private function makeTemplate(string $title, ?string $pageType): Template
+    {
+        $template = Template::create();
+        $template->Title = $title;
+        $template->PageType = $pageType;
+        $template->write();
+        // Template is Versioned; a plain front-end GET reads the Live stage, so
+        // publish it or the controller's byID() lookup 404s.
+        $template->publishSingle();
+
+        return $template;
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #81. The Category feature added untyped-template support in the model (`getAllowedTypes()` falls back to the base `Page`), but `TemplatePreviewController::index()` still returned `500 Invalid Page Type` when `PageType` was empty. That broke the template preview page and the "Capture Preview Image" CMS action for any untyped template.

This resolves an empty/unresolvable `PageType` to `\Page::class` in the controller too, matching the model's behaviour.

## Testing

- Replaced the two skipped controller tests with real ones: typed preview → 200, **untyped preview → 200** (the regression guard), missing ID → 404.
- Full suite: 49 tests pass, phpcs/phpstan clean.
- Verified against a live testbed: `/template-preview/{ID}?content_only=1` now returns 200 for untyped templates (was 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)