### PR TITLE
fix(#83): rebind add-page template dropdown to SS6 CMSMain hooks

### DIFF
--- a/_config/skeleton-config.yml
+++ b/_config/skeleton-config.yml
@@ -11,7 +11,14 @@ DNADesign\Elemental\Models\BaseElement:
   extensions:
     - Dynamic\ElementalTemplates\Extension\BaseElementDataExtension
 
-SilverStripe\CMS\Controllers\CMSPageAddController:
+# SS6 moved the add-page form off CMSPageAddController: the grouped template
+# dropdown is injected via CMSMainAddForm::updateFields(), and the template is
+# applied on create via CMSMain::updateDoAdd().
+SilverStripe\CMS\Forms\CMSMainAddForm:
+    extensions:
+        - Dynamic\ElementalTemplates\Extension\CMSPageAddControllerExtension
+
+SilverStripe\CMS\Controllers\CMSMain:
     extensions:
         - Dynamic\ElementalTemplates\Extension\CMSPageAddControllerExtension
 

--- a/src/Extension/CMSPageAddControllerExtension.php
+++ b/src/Extension/CMSPageAddControllerExtension.php
@@ -23,13 +23,23 @@ use Dynamic\ElementalTemplates\Service\TemplateApplicator;
 class CMSPageAddControllerExtension extends Extension
 {
     /**
-     * Update page options to include a template selection.
+     * Inject the grouped template picker into the "Add new page" form.
+     *
+     * SS6 builds this form in CMSMainAddForm (this hook fires from its
+     * createFields()); the page-type field is named "RecordType". Older
+     * versions used CMSPageAddController::updatePageOptions with a "PageType"
+     * field — both field names are handled so the dropdown lands in the right
+     * place regardless of CMS version.
      *
      * @param FieldList $fields
      * @return void
      */
-    public function updatePageOptions(FieldList $fields): void
+    public function updateFields(FieldList $fields): void
     {
+        if ($fields->dataFieldByName('TemplateID')) {
+            return;
+        }
+
         $title = '<span class="step-label"><span class="flyout">Step 3. </span><span class="title">(Optional) Select template to create page with</span></span>';
         $templateField = GroupedDropdownField::create(
             'TemplateID',
@@ -37,7 +47,13 @@ class CMSPageAddControllerExtension extends Extension
             Template::getGroupedTemplateMap()
         );
         $templateField->setEmptyString('Select template');
-        $fields->insertAfter('PageType', $templateField);
+
+        $anchor = $fields->dataFieldByName('RecordType') ? 'RecordType' : 'PageType';
+        if ($fields->dataFieldByName($anchor)) {
+            $fields->insertAfter($anchor, $templateField);
+        } else {
+            $fields->push($templateField);
+        }
     }
 
     /**
@@ -56,8 +72,11 @@ class CMSPageAddControllerExtension extends Extension
 
         $record->write();
 
-        $requestData = $form->getRequestData();
-        $templateID = (is_array($requestData) && array_key_exists('TemplateID', $requestData)) ? $requestData['TemplateID'] : null;
+        // Read the selected template from the POST submission. Form::getRequestData()
+        // holds the data the form was *built* with (the GET to /admin/pages/add),
+        // not the submitted values, so the TemplateID must come off the request.
+        $request = $form->getController() ? $form->getController()->getRequest() : null;
+        $templateID = $request ? $request->postVar('TemplateID') : null;
         if (!$templateID || !$template = Template::get()->byID($templateID)) {
             Injector::inst()->get(LoggerInterface::class)->warning(
                 "Invalid or missing template ID: {$templateID}."

--- a/tests/Extension/CMSPageAddControllerExtensionTest.php
+++ b/tests/Extension/CMSPageAddControllerExtensionTest.php
@@ -47,25 +47,51 @@ class CMSPageAddControllerExtensionTest extends SapphireTest
         Injector::inst()->registerService($mockLogger, LoggerInterface::class);
     }
 
-    public function testUpdatePageOptionsAddsGroupedTemplateDropdown(): void
+    public function testUpdateFieldsInsertsGroupedTemplateDropdownAfterRecordType(): void
     {
         $template = $this->objFromFixture(TestTemplate::class, 'testTemplate');
         $template->Category = 'Heroes';
         $template->write();
 
+        // SS6 add form: the page-type field is named "RecordType".
         $fields = new \SilverStripe\Forms\FieldList(
-            new \SilverStripe\Forms\HiddenField('PageType')
+            new \SilverStripe\Forms\HiddenField('RecordType')
         );
 
         $extension = new CMSPageAddControllerExtension();
-        $extension->updatePageOptions($fields);
+        $extension->updateFields($fields);
 
         $field = $fields->dataFieldByName('TemplateID');
         $this->assertInstanceOf(\SilverStripe\Forms\GroupedDropdownField::class, $field);
 
+        // Must sit immediately after RecordType (as "Step 3").
+        $names = array_map(fn ($f) => $f->getName(), $fields->dataFields());
+        $this->assertSame(
+            array_search('TemplateID', array_values($names), true),
+            array_search('RecordType', array_values($names), true) + 1
+        );
+
         $source = $field->getSource();
         $this->assertArrayHasKey('Heroes', $source);
         $this->assertContains($template->Title, $source['Heroes']);
+    }
+
+    public function testUpdateFieldsIsIdempotent(): void
+    {
+        $fields = new \SilverStripe\Forms\FieldList(
+            new \SilverStripe\Forms\HiddenField('RecordType')
+        );
+
+        $extension = new CMSPageAddControllerExtension();
+        $extension->updateFields($fields);
+        $extension->updateFields($fields);
+
+        // A second pass must not add a duplicate TemplateID field.
+        $matching = array_filter(
+            $fields->dataFields(),
+            fn ($f) => $f->getName() === 'TemplateID'
+        );
+        $this->assertCount(1, $matching);
     }
 
     public function testFindOrCreateElementalArea(): void
@@ -93,29 +119,46 @@ class CMSPageAddControllerExtensionTest extends SapphireTest
 
     public function testUpdateDoAdd(): void
     {
-        // Create a mock page and template
         $page = $this->objFromFixture(SamplePage::class, 'testPage');
         $template = $this->objFromFixture(TestTemplate::class, 'testTemplate');
 
-        // Mock the form
+        // The selected TemplateID comes off the POST request, reached via
+        // $form->getController()->getRequest()->postVar('TemplateID').
+        $request = new \SilverStripe\Control\HTTPRequest('POST', '/', [], ['TemplateID' => $template->ID]);
+        $controller = new \SilverStripe\Control\Controller();
+        $controller->setRequest($request);
+
         $mockForm = $this->createMock(Form::class);
-        $mockFields = $this->createMock(\SilverStripe\Forms\FieldList::class);
-        $mockField = $this->createMock(\SilverStripe\Forms\FormField::class);
+        $mockForm->method('getController')->willReturn($controller);
 
-        $mockField->method('getValue')->willReturn($template->ID);
-        $mockFields->method('dataFieldByName')->with('TemplateID')->willReturn($mockField);
-        $mockForm->method('Fields')->willReturn($mockFields);
-
-        // Apply the extension
         $extension = new CMSPageAddControllerExtension();
         $extension->setOwner($page);
-
-        // Call updateDoAdd
         $extension->updateDoAdd($page, $mockForm);
 
-        // Assert that the ElementalArea has elements from the template
         $elementalArea = $page->ElementalArea();
-        $this->assertNotNull($elementalArea, "ElementalArea is null");
-        $this->assertGreaterThan(0, $elementalArea->Elements()->count(), "ElementalArea has no elements");
+        $this->assertNotNull($elementalArea, 'ElementalArea is null');
+        $this->assertGreaterThan(0, $elementalArea->Elements()->count(), 'ElementalArea has no elements');
+    }
+
+    public function testUpdateDoAddWithoutTemplateIdIsNoOp(): void
+    {
+        $page = $this->objFromFixture(SamplePage::class, 'testPage');
+
+        // No TemplateID in the request: the page must be left without blocks.
+        $request = new \SilverStripe\Control\HTTPRequest('POST', '/', [], []);
+        $controller = new \SilverStripe\Control\Controller();
+        $controller->setRequest($request);
+
+        $mockForm = $this->createMock(Form::class);
+        $mockForm->method('getController')->willReturn($controller);
+
+        $before = $page->ElementalArea()->Elements()->count();
+
+        $extension = new CMSPageAddControllerExtension();
+        $extension->setOwner($page);
+        $extension->updateDoAdd($page, $mockForm);
+
+        // No template selected: element count must be unchanged.
+        $this->assertSame($before, $page->ElementalArea()->Elements()->count());
     }
 }


### PR DESCRIPTION
## Summary

The "Step 3 — select template" dropdown in the Add-new-page flow (and the apply-on-create behind it) has been dead since the SS6 upgrade: `CMSPageAddControllerExtension` targeted `CMSPageAddController`, which no longer exists in SS6. Browser testing surfaced it — the dropdown was simply absent from `/admin/pages/add`.

Rebinds the extension to the SS6 add flow:
- Applied to `CMSMainAddForm` (`updateFields`) and `CMSMain` (`updateDoAdd`) in `skeleton-config`.
- `updatePageOptions` → `updateFields`; inserts the grouped dropdown after the SS6 `RecordType` field (falls back to `PageType` for older CMS), now idempotent.
- `updateDoAdd` reads the selected `TemplateID` off the POST request — `Form::getRequestData()` returns the form's *construction* data, not the submission, so the template was never found.

Fixes #83. Complements the visual "Apply Template to Page" picker, which already worked in SS6.

## Testing

- 51 module tests pass (5 covering this extension: grouped-dropdown insertion after `RecordType`, idempotency, apply-with-TemplateID, no-op without it), phpcs/phpstan clean.
- **Verified in-browser end-to-end:** the "Step 3" dropdown renders with category optgroups (Heroes → Bold Hero Banner, etc.); creating a Block Page with "Service Cards (3 Column)" selected applied the full template — container, intro, three capability cards, and CTA — to the new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)